### PR TITLE
Add prefilled default names for runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "typestyle": "^2.0.4",
+        "unique-names-generator": "^4.7.1",
         "uuid": "^8.3.2",
         "ws": "^8.18.1",
         "y-websocket": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -511,6 +511,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "typestyle": "^2.0.4",
+    "unique-names-generator": "^4.7.1",
     "uuid": "^8.3.2",
     "ws": "^8.18.1",
     "y-websocket": "3.0.0",

--- a/src/ui/dialogs/runtimeSelector.ts
+++ b/src/ui/dialogs/runtimeSelector.ts
@@ -18,6 +18,7 @@ import type { Environment } from "@datalayer/core/lib/client/models/Environment"
 import type { IAuthProvider } from "../../services/interfaces/IAuthProvider";
 import { EnvironmentCache } from "../../services/cache/environmentCache";
 import { promptAndLogin } from "./authDialog";
+import { generateRuntimeName } from "../../utils/runtimeNameGenerator";
 
 /**
  * QuickPick item for runtime selection.
@@ -257,11 +258,15 @@ async function createRuntime(
   sdk: DatalayerClient,
   environment: Environment,
 ): Promise<Runtime | undefined> {
-  // Prompt for runtime name (human-readable)
+  // Generate a unique name suggestion
+  const suggestedName = generateRuntimeName();
+
+  // Prompt for runtime name (human-readable) with generated name as default
   const name = await vscode.window.showInputBox({
     title: `Create ${environment.title ?? environment.name} Runtime`,
     prompt: "Enter a friendly name for the new runtime",
-    placeHolder: `My ${environment.title ?? environment.name} Runtime`,
+    placeHolder: `e.g., ${suggestedName}`,
+    value: suggestedName, // Pre-populate with generated name
     validateInput: (value) => {
       if (!value || value.trim().length === 0) {
         return "Runtime name cannot be empty";

--- a/src/utils/runtimeNameGenerator.ts
+++ b/src/utils/runtimeNameGenerator.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021-2023 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * Runtime name generation utility using unique-names-generator.
+ * Generates friendly, memorable names for Datalayer runtimes.
+ *
+ * @module utils/runtimeNameGenerator
+ */
+
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  animals,
+  Config,
+} from "unique-names-generator";
+
+/**
+ * Configuration for unique name generation.
+ * Uses adjective + animal pattern for memorable runtime names.
+ */
+const nameConfig: Config = {
+  dictionaries: [adjectives, animals],
+  separator: "-",
+  length: 2,
+  style: "capital",
+};
+
+/**
+ * Generates a unique, human-readable name for a runtime.
+ * Uses the pattern: Adjective-Animal (e.g., "Brave-Tiger").
+ *
+ * @returns A generated runtime name with capitalized words separated by hyphens
+ *
+ * @example
+ * ```typescript
+ * const name = generateRuntimeName();
+ * // Returns something like: "Brave-Tiger"
+ * ```
+ */
+export function generateRuntimeName(): string {
+  return uniqueNamesGenerator(nameConfig);
+}


### PR DESCRIPTION
Fixes https://github.com/datalayer/vscode-datalayer/issues/13

![alegra](https://github.com/user-attachments/assets/3af19f3b-6d72-4175-a365-0238615fc561)
