### PR TITLE
Windsurf Compatibility Changes -- MCP Server, Multi-window functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ node_modules/
 
 # IDE
 .vscode-test/
+
+# Auto-generated per-window Windsurf MCP config (dynamic port — do not commit)
+.windsurf/mcp.json
 .vscode/datalayer-cells/
 *.suo
 *.ntvs*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -91,6 +91,9 @@ node_modules/**
 # Exclude examples from whitelisted @datalayer packages
 node_modules/@datalayer/*/lib/examples/**
 
+# --- Whitelist: MCP SDK for Windsurf/Cascade HTTP server ---
+!node_modules/@modelcontextprotocol/sdk/**
+
 # Exclude @primer/css (not imported, @primer/react is separate)
 node_modules/@primer/css/**
 

--- a/.windsurf/skills/datalayer-mcp/SKILL.md
+++ b/.windsurf/skills/datalayer-mcp/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: datalayer-mcp
+description: This skill is used for working with Jupyter notebooks and Datalayer documents using the Datalayer MCP tools. This is the only correct way to interact with a jupyter notebook.
+---
+
+# Datalayer MCP — The Required Method for Jupyter Notebook Work
+
+## When to Apply This Skill
+
+Apply this skill whenever a task involves **any** of the following:
+
+- Reading, inspecting, or understanding a `.ipynb` notebook's cells or outputs
+- Adding, editing, or deleting cells in a notebook
+- Running code or checking variable values in a live kernel
+- Creating a new Jupyter notebook or Datalayer document
+- Working with `.dlex` lexical documents
+- Debugging, refactoring, or extending notebook code
+- Analysing data that lives inside a running kernel
+
+---
+
+## CRITICAL: Never Use File Tools on Jupyter Notebooks
+
+**Do NOT use `read_file`, `edit`, `write_to_file`, `grep_search`, or any other file-system tool on `.ipynb` or `.dlex` files.**
+
+Jupyter notebooks are structured JSON documents containing embedded outputs, kernel state, cell execution counts, and cell IDs. Direct file manipulation:
+
+- **Corrupts cell outputs** — images, widgets, and rich HTML are base64-encoded blobs that break silently on edit
+- **Fabricates execution results** — reading a cell's "output" from disk gives stale or missing data; only the live kernel knows the true current state
+- **Loses kernel variable bindings** — the in-memory kernel state cannot be read from or written to a file
+- **Breaks cell ordering and IDs** — VS Code and Jupyter track cells by ID; file edits create ID collisions
+- **Produces malformed JSON** — a single formatting mistake makes the notebook completely unreadable
+
+The Datalayer MCP tools operate through the **live Datalayer editor and kernel**, giving Cascade the same access a human user has. This is the only correct way to interact with notebook or lexical content.
+
+---
+
+## Setup Requirements
+
+1. **Datalayer VS Code extension must be active** — running in Extension Development Host or installed normally.
+2. **MCP server must be listening** — logged as `MCP HTTP server listening on http://127.0.0.1:<port>/mcp` on activation (default port 3333). Configure Windsurf via `~/.codeium/windsurf/mcp_config.json`.
+3. **Document must be open in the Datalayer custom editor** — not the native VS Code notebook viewer. If the user opened a `.ipynb` with the built-in viewer, ask them to right-click → "Open With…" → "Datalayer Notebook Editor".
+
+---
+
+## Standard Operating Procedure
+
+### Step 1 — Always orient first
+
+Call `datalayer_getActiveDocument` before any other tool. It returns:
+- `uri` — document path (`file:///...` or `datalayer://...` for cloud)
+- `type` — `"notebook"` or `"lexical"`
+- `isConnected` — whether a kernel is connected
+
+Pass the returned `uri` as `notebook_uri` / `documentUri` in subsequent calls.
+
+**`datalayer_getActiveDocument` returns an open-documents list** appended after the active document info:
+
+```
+## Open Datalayer Documents
+1. analysis.ipynb (notebook) ← most recent
+   URI: `file:///path/to/analysis.ipynb`
+2. model-training.ipynb (notebook)
+   URI: `file:///path/to/model-training.ipynb`
+```
+
+The list is sorted by recency (most recently focused tab or last targeted by an MCP call is first). Use it to:
+- **Select the correct notebook** — match the user's request against filenames/topics in the list and pass the corresponding URI as `notebook_uri` / `documentUri` in all subsequent calls
+- **Detect ambiguity** — if multiple notebooks are open and the request is ambiguous, ask the user which one to target before proceeding
+- **Confirm the default** — if only one notebook is open, or the most-recent one clearly matches the request, proceed without asking
+
+If the target becomes unclear mid-task (e.g. the user mentions a different notebook), call `datalayer_getActiveDocument` again to get a refreshed list.
+
+### Step 2 — Connect a kernel if needed
+
+If `isConnected` is false, call `datalayer_listKernels` then `datalayer_selectKernel`. For zero-setup execution use `type="pyodide"`; for a new cloud runtime use `type="new"`; to reuse what's running use `type="active"`.
+
+### Step 3 — Read before writing
+
+Before modifying anything:
+- Notebooks → `datalayer_readAllCells` to see current cell sources and outputs
+- Lexical docs → `datalayer_readAllBlocks` to see document structure and block IDs
+
+### Step 4 — Execute using only Datalayer MCP tools
+
+See `tool-reference.md` for the full tool table, common workflow recipes, and error patterns.
+
+**Targeting a specific notebook:** If the user references a notebook by name or path and multiple notebooks are open, find the matching URI from the `uri` returned by `datalayer_getActiveDocument` or from context, and pass it as `notebook_uri` in all subsequent cell/kernel calls. Do not guess — if the URI is unclear, ask.
+
+### Step 5 — Verify after mutations
+
+After any insert/update/delete/run, read back the affected cell or block to confirm the result before continuing.

--- a/.windsurf/skills/datalayer-mcp/SKILL.md
+++ b/.windsurf/skills/datalayer-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datalayer-mcp
-description: This skill is used for working with Jupyter notebooks and Datalayer documents using the Datalayer MCP tools. This is the only correct way to interact with a jupyter notebook.
+description: Use this skill for working with Jupyter notebooks and Datalayer documents using the Datalayer MCP tools. This is the ONLY correct way to interact with a jupyter notebook.
 ---
 
 # Datalayer MCP — The Required Method for Jupyter Notebook Work

--- a/.windsurf/skills/datalayer-mcp/SKILL.md
+++ b/.windsurf/skills/datalayer-mcp/SKILL.md
@@ -78,15 +78,50 @@ If `isConnected` is false, call `datalayer_listKernels` then `datalayer_selectKe
 ### Step 3 — Read before writing
 
 Before modifying anything:
-- Notebooks → `datalayer_readAllCells` to see current cell sources and outputs
-- Lexical docs → `datalayer_readAllBlocks` to see document structure and block IDs
+- Notebooks → `datalayer_readAllCells` to see current cell sources and outputs (you need the cell count to compute insertion indices)
+- Lexical docs → `datalayer_readAllBlocks` to see document structure and block IDs (you need these IDs for update/delete)
 
-### Step 4 — Execute using only Datalayer MCP tools
+### Step 4 — Plan ALL remaining steps, then batch them
 
-See `tool-reference.md` for the full tool table, common workflow recipes, and error patterns.
+**After Step 3 you have all the information you need. Before making any writes, plan every remaining step to completion, then issue ALL of them in a single `datalayer_batch` call.**
 
-**Targeting a specific notebook:** If the user references a notebook by name or path and multiple notebooks are open, find the matching URI from the `uri` returned by `datalayer_getActiveDocument` or from context, and pass it as `notebook_uri` in all subsequent cell/kernel calls. Do not guess — if the URI is unclear, ask.
+This is the default. Individual tool calls after Step 3 are the exception, not the rule.
 
-### Step 5 — Verify after mutations
+**Batch decision rule — ask one question:**
+> "Do I know the params for ALL remaining steps right now, without needing to inspect any intermediate result?"
+- **Yes** → use `datalayer_batch`
+- **No** (one step's output determines the next step's params) → individual call, then re-evaluate
 
-After any insert/update/delete/run, read back the affected cell or block to confirm the result before continuing.
+**Always batch (params are fully known after read):**
+- Insert one or more cells + run them + read back output
+- Update a cell + run it + read back output
+- Delete cells + read state to confirm
+- Multiple sequential inserts at known indices
+- Insert block(s) + run + verify in a lexical doc
+
+**Always individual (intermediate result needed):**
+- You need to inspect a cell's output to decide *what* to write in the next cell
+- You need to check whether execution succeeded before deciding on a follow-up action
+- You're doing exploratory/debugging work where each result changes the plan
+
+```
+datalayer_getActiveDocument     → (1 call) orient, get URI
+datalayer_readAllCells          → (1 call) read state, learn cell count N
+datalayer_batch({               → (1 call) ALL remaining writes + verification
+  notebook_uri: "...",
+  operations: [
+    { tool: "datalayer_insertCell", params: { type: "code", source: "...", index: N } },
+    { tool: "datalayer_runCell",    params: { index: N } },
+    { tool: "datalayer_readCell",   params: { index: N } }
+  ]
+})
+```
+Three MCP calls total instead of five. **This is the standard pattern.**
+
+### Step 5 — Targeting the right document
+
+If the user references a notebook by name or path and multiple notebooks are open, find the matching URI from Step 1's open-documents list and pass it as `notebook_uri` in ALL subsequent calls including inside `datalayer_batch`. Do not guess — if the URI is unclear, ask.
+
+### Step 6 — Verify after mutations
+
+`datalayer_batch` returns results for every sub-operation. Check the `"success"` fields and the final `readCell` / `readBlock` output before reporting completion. If verification shows unexpected output, issue a follow-up individual tool call or a new batch to fix it.

--- a/.windsurf/skills/datalayer-mcp/tool-reference.md
+++ b/.windsurf/skills/datalayer-mcp/tool-reference.md
@@ -127,6 +127,7 @@ datalayer_runAllBlocks               → execute all cells in the report
 | `No Datalayer notebook is open` (after valid `getActiveDocument`) | Notebook was closed between calls | Re-call `getActiveDocument`; confirm notebook still open |
 | `Invalid response: 404 Not Found` on cloud ops | Not authenticated or token expired | Ask user: Command Palette → "Datalayer: Login" |
 | `MCP server not reachable` | Extension not running or port conflict | Reload window; check Datalayer output channel for port number |
+| `No Datalayer notebook is open in THIS window's editor, but notebooks are open in other VS Code windows: • Port XXXX: filename.ipynb` | The requested notebook is in a different VS Code window's MCP server | Switch to the VS Code window that has the notebook open — Cascade there will connect to that window's MCP server automatically. Or reopen the notebook in this window. |
 | Tools succeed but operate on the wrong notebook (different VS Code window) | MCP connected to another window's server (port collision) | On each activation the extension patches `~/.codeium/windsurf/mcp_config.json` with its port (Windsurf hot-reloads automatically). Reload the window you want Windsurf to target, then check the Datalayer output channel to confirm the port. |
 
 ---

--- a/.windsurf/skills/datalayer-mcp/tool-reference.md
+++ b/.windsurf/skills/datalayer-mcp/tool-reference.md
@@ -1,0 +1,137 @@
+# Datalayer MCP — Tool Reference
+
+## Tool Catalogue (20 tools)
+
+### Document Management
+
+| Tool | Description |
+|---|---|
+| `datalayer_getActiveDocument` | **Always call first.** Returns URI, type (`notebook`/`lexical`), and kernel connection state. |
+| `datalayer_createNotebook` | Create a new `.ipynb`. Defaults to cloud when authenticated, local otherwise. |
+| `datalayer_createLexical` | Create a new `.dlex` document. Same location logic. |
+
+### Kernel & Runtime
+
+| Tool | Description |
+|---|---|
+| `datalayer_listKernels` | List all available kernels: Datalayer cloud runtimes, local Python envs, Pyodide (WASM). |
+| `datalayer_selectKernel` | Connect a kernel. Values: `"pyodide"` (WASM, zero-setup), `"new"` (fresh cloud runtime), `"active"` (reuse running), or a specific kernel ID from `listKernels`. |
+| `datalayer_executeCode` | Execute arbitrary Python. Uses the active document's kernel; falls back to any running Datalayer runtime. Best tool for variable inspection without modifying cells. |
+
+### Notebook Operations (`.ipynb`)
+
+| Tool | Description |
+|---|---|
+| `datalayer_readAllCells` | All cells with source + outputs. Always call before editing. |
+| `datalayer_readCell` | Single cell by 0-based index. |
+| `datalayer_insertCell` | Add a code or markdown cell at a specific index. |
+| `datalayer_updateCell` | Overwrite a cell's source at a given index. |
+| `datalayer_deleteCells` | Remove one or more cells by index. |
+| `datalayer_runCell` | Execute a single cell and return its outputs. |
+
+### Lexical Document Operations (`.dlex`)
+
+| Tool | Description |
+|---|---|
+| `datalayer_readAllBlocks` | All blocks + document structure. Always call before editing. |
+| `datalayer_readBlock` | Single block by `block_id`. |
+| `datalayer_insertBlock` | Add a block (`heading`, `paragraph`, `jupyter-cell`, etc.). |
+| `datalayer_updateBlock` | Overwrite an existing block by `block_id`. |
+| `datalayer_deleteBlocks` | Remove one or more blocks by `block_id`. |
+| `datalayer_runBlock` | Execute a single `jupyter-cell` block by `block_id`. |
+| `datalayer_runAllBlocks` | Execute all `jupyter-cell` blocks in sequence. |
+| `datalayer_listAvailableBlocks` | Discover supported block types and their parameter schemas. |
+
+---
+
+## Common Workflows
+
+### Inspect a running notebook / read variable values
+
+```
+datalayer_getActiveDocument          → confirm URI + isConnected=true
+datalayer_readAllCells               → see all cell sources and current outputs
+datalayer_executeCode(code="...")    → interrogate live kernel variables
+```
+
+For structured variable inspection:
+```python
+import json
+print(json.dumps({"value": repr(my_var), "type": type(my_var).__name__, "shape": getattr(my_var, "shape", None)}))
+```
+
+### Add new analysis cells to an existing notebook
+
+```
+datalayer_getActiveDocument          → get URI, confirm kernel
+datalayer_readAllCells               → understand current state and total cell count
+datalayer_insertCell(index=N)        → add cell(s) at the right position
+datalayer_runCell(index=N)           → execute and verify output
+datalayer_readCell(index=N)          → confirm output is correct
+```
+
+### Start a new notebook on cloud
+
+```
+datalayer_createNotebook             → creates in cloud (when authenticated)
+datalayer_selectKernel(type="new")   → spin up a fresh Datalayer cloud runtime
+datalayer_insertCell(index=0)        → add initial code
+datalayer_runCell(index=0)           → execute
+```
+
+### Zero-setup execution (no Python install required)
+
+```
+datalayer_createNotebook             → creates locally in workspace
+datalayer_selectKernel(type="pyodide") → Pyodide WASM kernel, runs in browser
+datalayer_executeCode(code="...")    → run Python with no local install
+```
+
+### Create a Lexical report from notebook results
+
+```
+datalayer_getActiveDocument          → confirm notebook URI
+datalayer_readAllCells               → collect outputs to include
+datalayer_createLexical              → new .dlex document
+datalayer_listAvailableBlocks        → discover block types
+datalayer_insertBlock(type="heading") → add title
+datalayer_insertBlock(type="paragraph") → add narrative
+datalayer_insertBlock(type="jupyter-cell") → add executable code
+datalayer_runAllBlocks               → execute all cells in the report
+```
+
+---
+
+## Kernel Selection Cheat Sheet
+
+| Goal | `selectKernel` value | Notes |
+|---|---|---|
+| Reuse active cloud runtime | `"active"` | Fastest; preserves existing variable state |
+| New Datalayer cloud runtime | `"new"` | Uses `datalayer.runtime.defaultMinutes` setting |
+| Local Python environment | kernel ID from `listKernels` | Requires Python extension installed |
+| Zero-install browser execution | `"pyodide"` | Limited package support; no GPU |
+| Specific named runtime | ID string from `listKernels` | Use when multiple runtimes are running |
+
+---
+
+## Error Patterns & Fixes
+
+| Error message | Root cause | Resolution |
+|---|---|---|
+| `No Datalayer notebook is open` | File opened in native VS Code viewer, not Datalayer editor | Ask user: right-click file → "Open With…" → "Datalayer Notebook Editor" |
+| `Tool execution timeout (30s)` | Kernel busy, crashed, or disconnected | Call `datalayer_listKernels`; suggest `selectKernel(type="new")` |
+| `Document ID not registered` | Same cause as above — native editor was used | Same fix as above |
+| `No Datalayer notebook is open` (after valid `getActiveDocument`) | Notebook was closed between calls | Re-call `getActiveDocument`; confirm notebook still open |
+| `Invalid response: 404 Not Found` on cloud ops | Not authenticated or token expired | Ask user: Command Palette → "Datalayer: Login" |
+| `MCP server not reachable` | Extension not running or port conflict | Reload window; check Datalayer output channel for port number |
+
+---
+
+## Key Constraints
+
+- **Cell indices are 0-based.**
+- **Block IDs are opaque strings** returned by `readAllBlocks` — always read first before any insert/update/delete.
+- **One active document at a time** — tools target the best-available registered document. Pass `notebook_uri` / `documentUri` explicitly when multiple documents are open.
+- **`executeCode` does not modify the notebook** — it runs code in the live kernel without inserting a cell. Use it for inspection and ad-hoc queries; use `insertCell` + `runCell` when the code should persist in the notebook.
+- **Notebook ops require the Datalayer custom editor** — native VS Code `.ipynb` tabs are not supported.
+- **Lexical ops require a `.dlex` file** open in the Datalayer Lexical editor.

--- a/.windsurf/skills/datalayer-mcp/tool-reference.md
+++ b/.windsurf/skills/datalayer-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Datalayer MCP — Tool Reference
 
-## Tool Catalogue (20 tools)
+## Tool Catalogue (21 tools)
 
 ### Document Management
 
@@ -10,6 +10,7 @@
 | `datalayer_listOpenDocuments` | Returns all open notebooks and lexical docs sorted by most-recently-used. Use when you need to target a specific notebook by URI. |
 | `datalayer_createNotebook` | Create a new `.ipynb`. Defaults to cloud when authenticated, local otherwise. |
 | `datalayer_createLexical` | Create a new `.dlex` document. Same location logic. |
+| `datalayer_batch` | **Code Mode meta-tool.** Execute a JSON pipeline of `[{tool, params}]` operations in one MCP call — no LLM round-trips between steps. Pass `notebook_uri`/`documentUri` at top level to forward to all sub-ops. Set `stopOnError: false` to collect partial results. |
 
 ### Kernel & Runtime
 
@@ -61,7 +62,28 @@ import json
 print(json.dumps({"value": repr(my_var), "type": type(my_var).__name__, "shape": getattr(my_var, "shape", None)}))
 ```
 
-### Add new analysis cells to an existing notebook
+### Add new analysis cells to an existing notebook (single-step batch)
+
+Once you know the cell count, batch the mutations in one call:
+```
+datalayer_getActiveDocument          → get URI
+datalayer_readAllCells               → learn current cell count (N)
+datalayer_batch({
+  notebook_uri: "...",
+  operations: [
+    { tool: "datalayer_insertCell", params: { type: "code", source: "...", index: N } },
+    { tool: "datalayer_runCell",    params: { index: N } },
+    { tool: "datalayer_readCell",   params: { index: N } }
+  ]
+})                                   → insert + run + verify in one round-trip
+```
+
+**When to use `datalayer_batch`:**
+- You've already read the document state and are ready to mutate + verify
+- You have ≥ 2 sequential steps whose params don't depend on intermediate results
+- Keep reads that inform subsequent params (e.g. cell count) as separate upfront calls
+
+### Add new analysis cells to an existing notebook (multi-step, no batch)
 
 ```
 datalayer_getActiveDocument          → get URI, confirm kernel

--- a/.windsurf/skills/datalayer-mcp/tool-reference.md
+++ b/.windsurf/skills/datalayer-mcp/tool-reference.md
@@ -46,9 +46,34 @@
 
 ---
 
+## Batch Decision Guide
+
+**Default: use `datalayer_batch` for ALL writes after the initial read.**
+
+| Situation | Use |
+|---|---|
+| Insert cell(s) + run + verify | ✅ `datalayer_batch` |
+| Update cell(s) + run + verify | ✅ `datalayer_batch` |
+| Delete cells + read state | ✅ `datalayer_batch` |
+| Multiple sequential inserts at known indices | ✅ `datalayer_batch` |
+| Insert/update block(s) + run + verify | ✅ `datalayer_batch` |
+| Outcome of step N determines params of step N+1 | ❌ individual calls |
+| Exploratory debugging where each result changes the plan | ❌ individual calls |
+| Pure read (no mutations) | ❌ individual call |
+
+**The three-call pattern is the standard workflow:**
+```
+(1) datalayer_getActiveDocument   → orient, get URI
+(2) datalayer_readAllCells        → read state, get cell count N
+(3) datalayer_batch(notebook_uri, operations=[insert, run, read])
+```
+
+---
+
 ## Common Workflows
 
 ### Inspect a running notebook / read variable values
+*(reads only — no batching needed)*
 
 ```
 datalayer_getActiveDocument          → confirm URI + isConnected=true
@@ -62,65 +87,120 @@ import json
 print(json.dumps({"value": repr(my_var), "type": type(my_var).__name__, "shape": getattr(my_var, "shape", None)}))
 ```
 
-### Add new analysis cells to an existing notebook (single-step batch)
-
-Once you know the cell count, batch the mutations in one call:
-```
-datalayer_getActiveDocument          → get URI
-datalayer_readAllCells               → learn current cell count (N)
-datalayer_batch({
-  notebook_uri: "...",
-  operations: [
-    { tool: "datalayer_insertCell", params: { type: "code", source: "...", index: N } },
-    { tool: "datalayer_runCell",    params: { index: N } },
-    { tool: "datalayer_readCell",   params: { index: N } }
-  ]
-})                                   → insert + run + verify in one round-trip
-```
-
-**When to use `datalayer_batch`:**
-- You've already read the document state and are ready to mutate + verify
-- You have ≥ 2 sequential steps whose params don't depend on intermediate results
-- Keep reads that inform subsequent params (e.g. cell count) as separate upfront calls
-
-### Add new analysis cells to an existing notebook (multi-step, no batch)
+### Add cells to an existing notebook ✅ BATCH
 
 ```
-datalayer_getActiveDocument          → get URI, confirm kernel
-datalayer_readAllCells               → understand current state and total cell count
-datalayer_insertCell(index=N)        → add cell(s) at the right position
-datalayer_runCell(index=N)           → execute and verify output
-datalayer_readCell(index=N)          → confirm output is correct
+(1) datalayer_getActiveDocument      → get URI
+(2) datalayer_readAllCells           → learn current cell count N
+(3) datalayer_batch({
+      notebook_uri: "...",
+      operations: [
+        { tool: "datalayer_insertCell", params: { type: "code", source: "...", index: N } },
+        { tool: "datalayer_runCell",    params: { index: N } },
+        { tool: "datalayer_readCell",   params: { index: N } }
+      ]
+    })
+```
+3 MCP calls instead of 5.
+
+### Add multiple cells at once ✅ BATCH
+
+```
+(1) datalayer_getActiveDocument
+(2) datalayer_readAllCells           → N = current cell count
+(3) datalayer_batch({
+      notebook_uri: "...",
+      operations: [
+        { tool: "datalayer_insertCell", params: { type: "code", source: "import pandas as pd", index: N   } },
+        { tool: "datalayer_insertCell", params: { type: "code", source: "df = pd.read_csv('data.csv')", index: N+1 } },
+        { tool: "datalayer_insertCell", params: { type: "code", source: "df.head()", index: N+2 } },
+        { tool: "datalayer_runCell",    params: { index: N   } },
+        { tool: "datalayer_runCell",    params: { index: N+1 } },
+        { tool: "datalayer_runCell",    params: { index: N+2 } },
+        { tool: "datalayer_readCell",   params: { index: N+2 } }
+      ]
+    })
+```
+
+### Update an existing cell ✅ BATCH
+
+```
+(1) datalayer_getActiveDocument
+(2) datalayer_readAllCells           → find target cell index K
+(3) datalayer_batch({
+      notebook_uri: "...",
+      operations: [
+        { tool: "datalayer_updateCell", params: { index: K, source: "new code here" } },
+        { tool: "datalayer_runCell",    params: { index: K } },
+        { tool: "datalayer_readCell",   params: { index: K } }
+      ]
+    })
+```
+
+### Edit a lexical document ✅ BATCH
+
+```
+(1) datalayer_getActiveDocument
+(2) datalayer_readAllBlocks          → get block IDs and structure
+(3) datalayer_batch({
+      documentUri: "...",
+      operations: [
+        { tool: "datalayer_insertBlock",  params: { type: "paragraph", source: "...", afterId: "BOTTOM" } },
+        { tool: "datalayer_insertBlock",  params: { type: "jupyter-cell", source: "print('hello')", afterId: "BOTTOM" } },
+        { tool: "datalayer_runAllBlocks", params: {} }
+      ]
+    })
+```
+
+### Exploratory debugging ❌ INDIVIDUAL CALLS
+
+Use individual calls when each result informs the next step:
+```
+datalayer_getActiveDocument
+datalayer_readAllCells
+datalayer_runCell(index=K)           → inspect output; decide what to fix
+datalayer_updateCell(index=K, ...)   → fix based on what you saw
+datalayer_runCell(index=K)           → verify fix
 ```
 
 ### Start a new notebook on cloud
 
 ```
-datalayer_createNotebook             → creates in cloud (when authenticated)
-datalayer_selectKernel(type="new")   → spin up a fresh Datalayer cloud runtime
-datalayer_insertCell(index=0)        → add initial code
-datalayer_runCell(index=0)           → execute
+(1) datalayer_createNotebook         → creates in cloud (when authenticated)
+(2) datalayer_selectKernel(type="new")
+(3) datalayer_batch({
+      operations: [
+        { tool: "datalayer_insertCell", params: { type: "code", source: "import pandas as pd\nprint('ready')", index: 0 } },
+        { tool: "datalayer_runCell",    params: { index: 0 } },
+        { tool: "datalayer_readCell",   params: { index: 0 } }
+      ]
+    })
 ```
 
 ### Zero-setup execution (no Python install required)
 
 ```
-datalayer_createNotebook             → creates locally in workspace
-datalayer_selectKernel(type="pyodide") → Pyodide WASM kernel, runs in browser
-datalayer_executeCode(code="...")    → run Python with no local install
+(1) datalayer_createNotebook
+(2) datalayer_selectKernel(type="pyodide")
+(3) datalayer_executeCode(code="...")    → run Python immediately, no cell needed
 ```
 
 ### Create a Lexical report from notebook results
 
 ```
-datalayer_getActiveDocument          → confirm notebook URI
-datalayer_readAllCells               → collect outputs to include
-datalayer_createLexical              → new .dlex document
-datalayer_listAvailableBlocks        → discover block types
-datalayer_insertBlock(type="heading") → add title
-datalayer_insertBlock(type="paragraph") → add narrative
-datalayer_insertBlock(type="jupyter-cell") → add executable code
-datalayer_runAllBlocks               → execute all cells in the report
+(1) datalayer_getActiveDocument          → confirm notebook URI
+(2) datalayer_readAllCells               → collect outputs to summarise
+(3) datalayer_createLexical              → new .dlex document
+(4) datalayer_listAvailableBlocks        → discover block types and required params
+(5) datalayer_batch({
+      documentUri: "...",
+      operations: [
+        { tool: "datalayer_insertBlock", params: { type: "heading",      source: "Analysis Report", afterId: "BOTTOM" } },
+        { tool: "datalayer_insertBlock", params: { type: "paragraph",    source: "Summary of findings...", afterId: "BOTTOM" } },
+        { tool: "datalayer_insertBlock", params: { type: "jupyter-cell", source: "# key chart code", afterId: "BOTTOM" } }
+      ]
+    })
+(6) datalayer_runAllBlocks
 ```
 
 ---

--- a/.windsurf/skills/datalayer-mcp/tool-reference.md
+++ b/.windsurf/skills/datalayer-mcp/tool-reference.md
@@ -6,7 +6,8 @@
 
 | Tool | Description |
 |---|---|
-| `datalayer_getActiveDocument` | **Always call first.** Returns URI, type (`notebook`/`lexical`), and kernel connection state. |
+| `datalayer_getActiveDocument` | **Always call first.** Returns URI, type (`notebook`/`lexical`), and kernel connection state. Also appends a ranked list of all open documents. |
+| `datalayer_listOpenDocuments` | Returns all open notebooks and lexical docs sorted by most-recently-used. Use when you need to target a specific notebook by URI. |
 | `datalayer_createNotebook` | Create a new `.ipynb`. Defaults to cloud when authenticated, local otherwise. |
 | `datalayer_createLexical` | Create a new `.dlex` document. Same location logic. |
 
@@ -22,12 +23,12 @@
 
 | Tool | Description |
 |---|---|
-| `datalayer_readAllCells` | All cells with source + outputs. Always call before editing. |
-| `datalayer_readCell` | Single cell by 0-based index. |
-| `datalayer_insertCell` | Add a code or markdown cell at a specific index. |
-| `datalayer_updateCell` | Overwrite a cell's source at a given index. |
-| `datalayer_deleteCells` | Remove one or more cells by index. |
-| `datalayer_runCell` | Execute a single cell and return its outputs. |
+| `datalayer_readAllCells` | All cells with source + outputs. Always call before editing. Accepts optional `notebook_uri`. |
+| `datalayer_readCell` | Single cell by 0-based index. Accepts optional `notebook_uri`. |
+| `datalayer_insertCell` | Add a code or markdown cell at a specific index. Accepts optional `notebook_uri`. |
+| `datalayer_updateCell` | Overwrite a cell's source at a given index. Accepts optional `notebook_uri`. |
+| `datalayer_deleteCells` | Remove one or more cells by index. Accepts optional `notebook_uri`. |
+| `datalayer_runCell` | Execute a single cell and return its outputs. Accepts optional `notebook_uri`. |
 
 ### Lexical Document Operations (`.dlex`)
 
@@ -118,12 +119,15 @@ datalayer_runAllBlocks               → execute all cells in the report
 
 | Error message | Root cause | Resolution |
 |---|---|---|
-| `No Datalayer notebook is open` | File opened in native VS Code viewer, not Datalayer editor | Ask user: right-click file → "Open With…" → "Datalayer Notebook Editor" |
+| `"filename.ipynb" is open in the native VS Code notebook viewer, not the Datalayer editor` | File opened via native viewer, not Datalayer custom editor | A VS Code notification will appear with a one-click "Reopen in Datalayer Editor" button. Tell the user to click it, or: right-click file in Explorer → "Open With…" → "Datalayer Notebook Editor" |
+| `No notebook is open in the Datalayer editor` | No `.ipynb` files open at all in Datalayer | Tell user to open the notebook via right-click → "Open With…" → "Datalayer Notebook Editor" |
+| `The Datalayer notebook is still loading (webview not ready yet)` | Notebook is open in Datalayer editor but the React app hasn't finished initialising | Wait 3–5 seconds, then retry the tool call. This is transient and resolves on its own. |
 | `Tool execution timeout (30s)` | Kernel busy, crashed, or disconnected | Call `datalayer_listKernels`; suggest `selectKernel(type="new")` |
-| `Document ID not registered` | Same cause as above — native editor was used | Same fix as above |
+| `Document ID not registered` | Native editor used instead of Datalayer | Same fix as native viewer error above |
 | `No Datalayer notebook is open` (after valid `getActiveDocument`) | Notebook was closed between calls | Re-call `getActiveDocument`; confirm notebook still open |
 | `Invalid response: 404 Not Found` on cloud ops | Not authenticated or token expired | Ask user: Command Palette → "Datalayer: Login" |
 | `MCP server not reachable` | Extension not running or port conflict | Reload window; check Datalayer output channel for port number |
+| Tools succeed but operate on the wrong notebook (different VS Code window) | MCP connected to another window's server (port collision) | On each activation the extension patches `~/.codeium/windsurf/mcp_config.json` with its port (Windsurf hot-reloads automatically). Reload the window you want Windsurf to target, then check the Datalayer output channel to confirm the port. |
 
 ---
 
@@ -132,6 +136,7 @@ datalayer_runAllBlocks               → execute all cells in the report
 - **Cell indices are 0-based.**
 - **Block IDs are opaque strings** returned by `readAllBlocks` — always read first before any insert/update/delete.
 - **One active document at a time** — tools target the best-available registered document. Pass `notebook_uri` / `documentUri` explicitly when multiple documents are open.
+- **`notebook_uri` targets a specific notebook** — all cell tools accept an optional `notebook_uri` parameter. Get the URI from `datalayer_listOpenDocuments` or from the open-documents list in the `datalayer_getActiveDocument` response. When multiple notebooks are open, always pass this explicitly rather than relying on focus detection.
 - **`executeCode` does not modify the notebook** — it runs code in the live kernel without inserting a cell. Use it for inspection and ad-hoc queries; use `insertCell` + `runCell` when the code should persist in the notebook.
 - **Notebook ops require the Datalayer custom editor** — native VS Code `.ipynb` tabs are not supported.
 - **Lexical ops require a `.dlex` file** open in the Datalayer Lexical editor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Cascade calls tool via MCP  →  same handler → same BridgeExecutor/direct pat
 
 ---
 
-## The 21 Tools
+## The 22 Tools
 
 ### Document Management
 | Tool | Description |
@@ -63,6 +63,7 @@ Cascade calls tool via MCP  →  same handler → same BridgeExecutor/direct pat
 | `datalayer_listOpenDocuments` | List all open notebooks and lexical docs sorted by most-recently-used. Returns URIs for targeting specific docs via `notebook_uri`/`documentUri`. |
 | `datalayer_createNotebook` | Create a local or cloud `.ipynb` notebook |
 | `datalayer_createLexical` | Create a local or cloud `.lexical` document |
+| `datalayer_batch` | **Code Mode meta-tool.** Executes a JSON pipeline of `[{tool, params}]` operations in one MCP call. Eliminates LLM round-trips between mechanical steps. Pass `notebook_uri`/`documentUri` at the top level to forward to all sub-ops. |
 
 ### Kernel & Runtime
 | Tool | Description |
@@ -109,6 +110,8 @@ Cascade calls tool via MCP  →  same handler → same BridgeExecutor/direct pat
 | `src/tools/definitions/` | Tool definition objects (name, description, inputSchema). Local VS Code-specific tools only; notebook/lexical tools come from upstream packages. |
 | `src/tools/definitions/listOpenDocuments.ts` | New: lists all open documents sorted by recency |
 | `src/tools/operations/listOpenDocuments.ts` | New: implementation using `DocumentRegistry.getByType()` |
+| `src/tools/definitions/batch.ts` | `datalayer_batch` tool definition (Code Mode meta-tool) |
+| `src/tools/operations/batch.ts` | Stub operation for VS Code/Copilot path; real logic lives in `mcpServer.ts` |
 | `src/tools/schemas/` | Zod validation schemas per tool |
 | `src/tools/operations/` | Business logic implementations |
 | `src/mcp/mcpServer.ts` | MCP HTTP server — `buildMcpExecutionContext()` contains the tag-based routing logic |
@@ -205,6 +208,8 @@ The actual port is logged to the Datalayer output channel on activation.
 3. **`AGENTS.md`** (this file) — update tool tables, caveats, architecture notes, and key files as needed
 4. **Windsurf skills** — if tool behaviour or schemas change, update **only** `.windsurf/skills/datalayer-mcp/` (the local workspace copy). Do **not** modify `~/.codeium/windsurf/skills/datalayer-mcp/` (the user's global skill, maintained separately outside this repo).
 5. **`package.json`** — bump the version for every releasable change
+6. **`.windsurf/skills/datalayer-mcp/tool-reference.md`** — update the tool reference documentation to reflect the current state of the tools
+7. **`.windsurf/skills/datalayer-mcp/SKILL.md`** — update the skill documentation to reflect the current state of the tools and approach if anything has substantially changed in how the MCP server is meant to be used.
 
 Failing to update these files leaves Cascade and future contributors with stale context, which directly causes the class of bugs seen during this development cycle.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS.md — Datalayer VS Code Extension: Windsurf/Cascade Integration
+
+## What This Repo Is
+
+`vscode-datalayer` is an open-source VS Code extension (MIT License) by Datalayer, Inc.
+It provides a collaborative Jupyter notebook and Lexical document editor inside VS Code,
+with cloud runtime support (CPU/GPU), a `datalayer://` virtual filesystem, LSP cell
+completions, and 21 AI tools registered via VS Code's Language Model Tools API.
+
+**Upstream repo**: https://github.com/datalayer/vscode-datalayer  
+**Extension publisher ID**: `datalayer.datalayer-jupyter-vscode`  
+**Entry point**: `src/extension.ts` (38-step async activation sequence)
+
+---
+
+## The Goal of This Fork
+
+**GitHub Copilot can use all 21 DataLayer tools** because it invokes them via VS Code's
+`vscode.lm.invokeTool()` API. **Windsurf/Cascade cannot**, because Cascade uses MCP
+(Model Context Protocol) over HTTP, not the VS Code LM API.
+
+**The goal is to add an MCP HTTP server** to this extension so that Windsurf/Cascade
+gains the same 21-tool access to DataLayer notebooks that Copilot currently has.
+
+---
+
+## Architecture Overview
+
+### Current Tool Registration (Copilot path)
+
+```
+extension.ts  →  registerVSCodeTools(context)
+                    └─ getCombinedOperations()          ← merges 3 operation registries
+                    └─ vscode.lm.registerTool(name, VSCodeToolAdapter)
+                                                        ↑ Copilot calls vscode.lm.invokeTool()
+
+VSCodeToolAdapter.invoke()
+    ├─ VS Code-specific ops (getActiveDocument, createNotebook, executeCode, listKernels,
+    │   selectKernel, createLexical)  →  run directly in extension host
+    └─ Notebook/lexical ops (insertCell, readAllCells, runCell, insertBlock, …)
+           └─ BridgeExecutor  →  postMessage → webview → @datalayer/jupyter-react
+```
+
+### Desired MCP path (Windsurf/Cascade)
+
+```
+extension.ts  →  startMcpServer()   (new — runs alongside existing step)
+                    └─ getCombinedOperations()          ← same registry, no duplication
+                    └─ McpServer.tool(name, handler)    ← @modelcontextprotocol/sdk
+                    └─ StreamableHTTPServerTransport    ← http://localhost:3333/mcp
+
+Cascade calls tool via MCP  →  same handler → same BridgeExecutor/direct path as Copilot
+```
+
+---
+
+## The 21 Tools
+
+### Document Management
+| Tool | Description |
+|---|---|
+| `datalayer_getActiveDocument` | Get URI + type of currently active doc. **Call first before any other op.** Also returns a ranked list of all open docs. |
+| `datalayer_listOpenDocuments` | List all open notebooks and lexical docs sorted by most-recently-used. Returns URIs for targeting specific docs via `notebook_uri`/`documentUri`. |
+| `datalayer_createNotebook` | Create a local or cloud `.ipynb` notebook |
+| `datalayer_createLexical` | Create a local or cloud `.lexical` document |
+
+### Kernel & Runtime
+| Tool | Description |
+|---|---|
+| `datalayer_listKernels` | List local Jupyter, cloud Datalayer, and Pyodide (WASM) kernels |
+| `datalayer_selectKernel` | Connect a kernel to the active doc (`pyodide`, `new`, `active`, `local`, or ID) |
+| `datalayer_executeCode` | Execute arbitrary Python code in the connected kernel |
+
+### Notebook-Specific (`.ipynb`)
+| Tool | Description |
+|---|---|
+| `datalayer_insertCell` | Add a code or markdown cell. Accepts optional `notebook_uri` to target a specific notebook. |
+| `datalayer_updateCell` | Modify existing cell content. Accepts optional `notebook_uri`. |
+| `datalayer_deleteCell` | Remove a cell. Accepts optional `notebook_uri`. |
+| `datalayer_readCell` | Read a single cell. Accepts optional `notebook_uri`. |
+| `datalayer_readAllCells` | Read all cells (brief or full). Accepts optional `notebook_uri`. |
+| `datalayer_runCell` | Execute a specific cell. Accepts optional `notebook_uri`. |
+| `datalayer_runAllCells` | Execute all cells in sequence |
+
+### Lexical Document (`.dlex` / `.lexical`)
+| Tool | Description |
+|---|---|
+| `datalayer_insertBlock` | Add a block (heading, paragraph, jupyter-cell, etc.) |
+| `datalayer_insertBlocks` | Add multiple blocks efficiently |
+| `datalayer_updateBlock` | Modify an existing block |
+| `datalayer_deleteBlock` | Remove a block |
+| `datalayer_readBlock` | Read a single block |
+| `datalayer_readAllBlocks` | Read all blocks and document structure |
+| `datalayer_runBlock` | Execute a jupyter-cell block |
+| `datalayer_runAllBlocks` | Execute all jupyter-cell blocks |
+| `datalayer_listAvailableBlocks` | List supported block types and metadata formats |
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `src/extension.ts` | 38-step activation. Add MCP server startup here (after step 22 "Registering MCP tools") |
+| `src/tools/core/registration.ts` | `registerVSCodeTools()`, `getCombinedOperations()` — reuse this for MCP |
+| `src/tools/core/toolAdapter.ts` | `VSCodeToolAdapter` — reference for how tools are invoked |
+| `src/tools/core/BridgeExecutor.ts` | Webview postMessage bridge — notebook/lexical ops go through here |
+| `src/tools/core/runnerSetup.ts` | Creates `Runner` with smart executor routing |
+| `src/tools/definitions/` | Tool definition objects (name, description, inputSchema). Local VS Code-specific tools only; notebook/lexical tools come from upstream packages. |
+| `src/tools/definitions/listOpenDocuments.ts` | New: lists all open documents sorted by recency |
+| `src/tools/operations/listOpenDocuments.ts` | New: implementation using `DocumentRegistry.getByType()` |
+| `src/tools/schemas/` | Zod validation schemas per tool |
+| `src/tools/operations/` | Business logic implementations |
+| `src/mcp/mcpServer.ts` | MCP HTTP server — `buildMcpExecutionContext()` contains the tag-based routing logic |
+| `src/services/documents/documentRegistry.ts` | `lastUsed` tracking, `touch()`, `startTabWatcher()`, `getBestWebviewPanel()` |
+| `package.json` | `languageModelTools` contribution point — reference for MCP tool schemas (Copilot path only; MCP path loads schemas dynamically via `getAllToolDefinitionsAsync()`) |
+
+---
+
+## Current Architecture (as implemented)
+
+The MCP server is **already implemented and running**. This section documents how it works.
+
+### MCP Server startup
+
+`extension.ts` starts the MCP server as an optional activation step after tool registration:
+
+```typescript
+await runOptionalActivationStep("Starting MCP HTTP server for Windsurf/Cascade", async () => {
+  const { startMcpServer } = await import("./mcp/mcpServer");
+  const mcpHttpServer = await startMcpServer(context, services!, ui!);
+  context.subscriptions.push({ dispose: () => mcpHttpServer.close() });
+  context.subscriptions.push(services!.documentRegistry.startTabWatcher());
+});
+```
+
+### Tool routing in `buildMcpExecutionContext`
+
+For each MCP tool call, the handler classifies the tool via its tags:
+
+```typescript
+const isPrerequisiteTool = tags.includes("prerequisite"); // skip doc resolution entirely
+const needsCellDocument  = !isPrerequisiteTool && tags.includes("cell");   // → resolveNotebookId()
+const needsBlockDocument = !isPrerequisiteTool &&
+  (tags.includes("block") || tags.includes("blocks"));                      // → resolveLexicalId()
+const isCreateOperation  = tags.includes("create");                         // → no document needed
+```
+
+**Critical:** Use `"block"`/`"blocks"` — NOT `"lexical"` — to detect block operations.
+`"lexical"` is a domain descriptor shared by cross-domain tools (`listKernels`, `selectKernel`,
+`executeCode`). Every actual block operation tool carries `"block"` or `"blocks"`; none of
+the cross-domain tools do. Using `"lexical"` as the discriminator causes those tools to
+erroneously call `resolveLexicalId()` and fail when no `.dlex` file is open.
+
+### Configure Windsurf
+
+The extension automatically writes a workspace-level `.windsurf/mcp.json` to the workspace root on every activation. Windsurf reads this file and overrides the global `mcp_config.json` for that workspace. **No manual configuration is needed** for new workspaces after installing the extension.
+
+For a global fallback (e.g. opening a folder that has never had the extension run in it), you can still add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "datalayer": {
+      "serverUrl": "http://localhost:3333/mcp"
+    }
+  }
+}
+```
+
+The actual port is logged to the Datalayer output channel on activation.
+
+---
+
+## Caveats & Open Questions
+
+- **Multi-window auto-config**: Each VS Code window's extension claims a port from 3333–3340. On startup, the extension writes `.windsurf/mcp.json` to the workspace root with its actual port. Windsurf reads this workspace-level config (overriding the global `mcp_config.json`) so each window's Cascade agent connects to the correct server automatically. The file is gitignored. After installing a new VSIX in a new workspace for the first time, the user may need to reload the window once for Windsurf to pick up the new workspace config.
+
+  **How it actually works (alpha.10+):** Windsurf has NO workspace-level MCP config override — it only reads `~/.codeium/windsurf/mcp_config.json`. The extension now patches that global file directly on startup (preserving all other server entries), and Windsurf hot-reloads only the `datalayer` entry automatically. The workspace `.windsurf/mcp.json` is still written as a transparency artifact.
+
+- **BridgeExecutor webview dependency**: Cell/block operations require an active DataLayer
+  webview. If no DataLayer notebook is open, those tools will fail gracefully. Document
+  this clearly in tool descriptions for Cascade.
+
+- **Authentication**: DataLayer cloud operations require auth. The MCP server inherits
+  the same auth state as the extension (already managed by `ServiceContainer`), so no
+  separate auth is needed.
+
+- **Multi-notebook targeting**: All cell tools now accept an optional `notebook_uri` parameter.
+  When multiple notebooks are open, Cascade should call `datalayer_listOpenDocuments` to
+  discover URIs and pass the target notebook's URI explicitly rather than relying on
+  focus detection.
+
+- **Upstream PR**: This change is a clean optional activation step and adds no breaking
+  changes. It is worth submitting upstream to the DataLayer repo.
+
+---
+
+## Documentation Update Policy
+
+**Every code change to the MCP server, tool definitions, or document registry MUST include updates to:**
+
+1. **`CHANGELOG.md`** — describe the change under `[Unreleased]` with the target version tag (e.g. `0.0.16-alpha.N`)
+2. **`README.md`** — update the Recent Updates section and any feature bullets affected
+3. **`AGENTS.md`** (this file) — update tool tables, caveats, architecture notes, and key files as needed
+4. **Windsurf skills** — if tool behaviour or schemas change, update **only** `.windsurf/skills/datalayer-mcp/` (the local workspace copy). Do **not** modify `~/.codeium/windsurf/skills/datalayer-mcp/` (the user's global skill, maintained separately outside this repo).
+5. **`package.json`** — bump the version for every releasable change
+
+Failing to update these files leaves Cascade and future contributors with stale context, which directly causes the class of bugs seen during this development cycle.
+
+> **Reminder to Cascade:** On every conversation turn that modifies MCP server behaviour, tool definitions, or operation logic, end by verifying that `.windsurf/skills/datalayer-mcp/tool-reference.md` reflects the change. The global skill at `~/.codeium/windsurf/skills/datalayer-mcp/` is the user's personal copy and must **not** be touched.
+
+---
+
+## Development Setup
+
+```bash
+cd /Users/alpenkar/Documents/Code/vscode-datalayer
+npm install
+npm run compile        # webpack build
+# Press F5 in VS Code to launch Extension Development Host
+```
+
+Requires Node.js 22.x (see `package.json` `engines` field).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ## [Unreleased]
 
+### Added (April 2025) — `0.0.17-alpha.adp11`
+
+- **Cross-window notebook registry via `globalState`**: New `CrossWindowRegistry` class (`src/mcp/crossWindowRegistry.ts`) uses VS Code's `ExtensionContext.globalState` (shared across all windows) to broadcast each window's open notebooks and MCP port. Every 15 seconds the registry writes a heartbeat + current notebook list; entries older than 45 seconds are treated as stale (window closed). When an MCP tool call fails to find a notebook locally, it now checks `globalState` for other active windows and returns an informative error listing exactly which notebooks are open in other windows and on which port, guiding the user to switch to the correct Cascade session or reopen the notebook in the current window.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp11`
+
+- **MathJax stretchy brackets now render in markdown**: LaTeX commands like `\underbrace`, `\overbrace`, and `\underbracket` now render correctly in notebook markdown cells. Previously these stretchy delimiters appeared blank because the MathJax Size fonts (`MJXTEX-S1..S4`) were never loaded. Fixed by importing `@jupyterlab/mathjax-extension/style/base.css` in the webview entry point, which webpack processes to emit the 22 MathJax WOFF font files and inject the required `@font-face` declarations at runtime.
+
 ### Fixed (April 2025) — `0.0.17-alpha.adp10`
 
 - **Multi-window MCP config now writes to the correct file**: `0.0.16-alpha.9` wrote a workspace-level `.windsurf/mcp.json`, but Windsurf **only** reads `~/.codeium/windsurf/mcp_config.json` — there is no workspace-level config override. The extension now updates the global `mcp_config.json` directly: it reads the existing file, patches only the `datalayer` entry with the claimed port, and writes it back, preserving all other servers. Windsurf hot-reloads the affected server automatically when the file changes (no manual refresh required). The workspace-level `.windsurf/mcp.json` is still written as a transparency artifact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ## [Unreleased]
 
+### Fixed (April 2025) — `0.0.17-alpha.adp10`
+
+- **Multi-window MCP config now writes to the correct file**: `0.0.16-alpha.9` wrote a workspace-level `.windsurf/mcp.json`, but Windsurf **only** reads `~/.codeium/windsurf/mcp_config.json` — there is no workspace-level config override. The extension now updates the global `mcp_config.json` directly: it reads the existing file, patches only the `datalayer` entry with the claimed port, and writes it back, preserving all other servers. Windsurf hot-reloads the affected server automatically when the file changes (no manual refresh required). The workspace-level `.windsurf/mcp.json` is still written as a transparency artifact.
+
 ### Added (April 2025) — `0.0.17-alpha.adp2`
 
 - **Intelligent multi-notebook selection for MCP**: When multiple Datalayer notebooks are open, MCP tool calls now target the correct notebook intelligently rather than defaulting to insertion order.
@@ -26,6 +30,36 @@ All notable changes to the Datalayer VS Code extension are documented here.
   - Server startup failure is non-fatal: logged as a warning so extension activation is never blocked
   - Configure Windsurf via `~/.codeium/windsurf/mcp_config.json` — see `src/mcp/README.md`
   - New npm dependency: `@modelcontextprotocol/sdk@1.29.0` (externalized in webpack, whitelisted in `.vscodeignore`)
+
+### Fixed (April 2025) — `0.0.16-alpha.9`
+
+- **Multi-window MCP port collision**: When multiple VS Code windows are open, each window's Datalayer extension claims a different port (3333–3340). Previously only the window on port 3333 was reachable. Fixed by writing `.windsurf/mcp.json` on startup (superseded by alpha.10 which correctly targets the global config).
+
+### Fixed (April 2025) — `0.0.16-alpha.8`
+
+- **Webview-not-ready race condition**: Even after the early `register()` fix in alpha.7, tool calls made while the Datalayer React app was still initialising would time out after 30 seconds (the webview panel existed in the registry but couldn't handle messages yet). Fixed by:
+  1. Adding `isWebviewReady: boolean` to `DocumentRegistryEntry` — set `false` on early registration, `true` when `handleReadyMessage` fires (i.e. the webview has sent its `"ready"` handshake).
+  2. Adding `markWebviewReady(documentUri)` to `DocumentRegistry`, called from `handleReadyMessage` in `notebookProvider.ts`.
+  3. Replacing `getBestWebviewPanel()` in the MCP executor with `getBestWebviewPanelWithStatus()`, which now throws a precise `"notebook still loading, please wait and retry"` error instead of hitting the 30-second timeout.
+  4. `getBestWebviewPanel()` now prefers ready panels over not-yet-ready panels.
+
+### Fixed (April 2025) — `0.0.16-alpha.7`
+
+- **Race condition: registry empty when webview hasn't loaded yet** (root cause of most "no notebook found" errors): The `documentRegistry.register()` call in `notebookProvider.ts` was inside `handleReadyMessage()`, which is only triggered after the Datalayer webview React app finishes loading and sends a `"ready"` message. This takes several seconds. Any MCP tool call made before that point found an empty registry and failed — even though the notebook was visibly open in the Datalayer editor. Fixed by adding an early `register()` call directly in `resolveCustomEditor()` (immediately after the webview HTML is set), before any async work or message-handler setup.
+
+### Fixed (April 2025) — `0.0.16-alpha.6`
+
+- **Native VS Code notebook viewer detection**: When an `.ipynb` file is open in the native VS Code notebook viewer instead of the Datalayer custom editor, MCP tools previously returned a generic "No Datalayer notebook is open" error. The server now scans all open tabs, detects notebooks in the native viewer, fires a VS Code warning notification with a **"Reopen in Datalayer Editor"** action button, and throws a precise, actionable error message. Clicking the notification button automatically reopens the file in the correct editor.
+
+### Fixed (April 2025) — `0.0.16-alpha.5`
+
+- **`datalayer_listKernels`, `datalayer_selectKernel`, and `datalayer_executeCode` incorrectly required a lexical document**: `buildMcpExecutionContext` used `tags.includes("lexical")` as the discriminator for `needsBlockDocument`, causing these cross-domain tools to fail with `"No Lexical document is open"` when no `.dlex` file was open. Fixed by switching to `tags.includes("block") || tags.includes("blocks")`. Every actual block operation tool carries one of these tags; no cross-domain tool does.
+
+### Added (April 2025) — `0.0.16-alpha.4`
+
+- **`datalayer_listOpenDocuments` tool**: New VS Code-specific tool that returns every Jupyter notebook and Datalayer lexical document currently open in the Datalayer editor, sorted by most-recently-used first. Returns `uri`, `filename`, `type`, `rank`, and `mostRecent` for each document.
+
+- **`notebook_uri` parameter on all notebook cell tools**: All six notebook cell tools (`readAllCells`, `readCell`, `insertCell`, `updateCell`, `deleteCells`, `runCell`) now expose `notebook_uri` as an optional input parameter in their MCP schema. Cascade can now target any open notebook by URI rather than relying on whichever notebook happens to be focused in VS Code.
 
 ### Fixed (April 2025) — `0.0.16-alpha.3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ## [Unreleased]
 
-## [0.0.17-alpha.adp1] - 2026-04-29
+### Added (April 2025) — `0.0.17-alpha.adp2`
 
-### Added (April 2025)
+- **Intelligent multi-notebook selection for MCP**: When multiple Datalayer notebooks are open, MCP tool calls now target the correct notebook intelligently rather than defaulting to insertion order.
+  - `DocumentRegistryEntry` gains a `lastUsed: number` timestamp (set on registration, updated on every MCP tool call and on VS Code tab focus).
+  - `DocumentRegistry.touch(documentId)` — new method that refreshes `lastUsed` for a given entry.
+  - `DocumentRegistry.getByType()` — now returns entries sorted by `lastUsed` descending so all callers automatically prefer the most-recently-used document.
+  - `DocumentRegistry.startTabWatcher()` — new method that subscribes to `vscode.window.tabGroups.onDidChangeTabs`. Manually clicking a Datalayer notebook or lexical tab in VS Code now updates `lastUsed` for that document, keeping selection intent consistent whether the user interacts through the editor or through Cascade.
+  - Wired up in `extension.ts` alongside the MCP server startup so the watcher's lifecycle is tied to the extension.
+  - `resolveNotebookId` / `resolveLexicalId` in the MCP path call `touch()` after resolving the target document.
+  - `buildOpenDocumentsContext()` — appended to `datalayer_getActiveDocument` responses only. Returns a ranked list of all open documents (URI, type, recency order) so Cascade can make an informed document choice based on the user's request without polluting every other tool's output.
+
+- **Windsurf Skill**: Added `.windsurf/skills/datalayer-mcp/` to the repository with `SKILL.md` and `tool-reference.md`. These teach Cascade how to use the MCP server as the authoritative, required interface for all Jupyter notebook and Datalayer document work — replacing any direct file-system access to `.ipynb` / `.dlex` files.
+
+### Added (April 2025) — `0.0.17-alpha.adp1`
 
 - **Windsurf / Cascade MCP Integration**: All 22 Datalayer tools are now accessible to Windsurf/Cascade via a local HTTP MCP (Model Context Protocol) server
   - New file: `src/mcp/mcpServer.ts` — starts a stateless `StreamableHTTPServerTransport` server on `http://localhost:3333/mcp` (auto-scans 3333–3340 for a free port)
@@ -16,7 +27,11 @@ All notable changes to the Datalayer VS Code extension are documented here.
   - Configure Windsurf via `~/.codeium/windsurf/mcp_config.json` — see `src/mcp/README.md`
   - New npm dependency: `@modelcontextprotocol/sdk@1.29.0` (externalized in webpack, whitelisted in `.vscodeignore`)
 
-### Fixed (April 2025)
+### Fixed (April 2025) — `0.0.16-alpha.2`
+
+- **Multi-notebook ambiguity**: Previously, when no Datalayer editor tab was focused (e.g. Cascade panel was active) and multiple notebooks were open, the MCP path always picked the first registered notebook regardless of what the user was working on. The new `lastUsed`-sorted `getByType()` and `startTabWatcher()` ensure the most recently focused or most recently used notebook is selected by default.
+
+### Fixed (April 2025) — `0.0.16-alpha.1`
 
 - **MCP tool execution when Cascade panel is focused**: `DocumentRegistry.getBestWebviewPanel()` added as a fallback to `getActiveWebviewPanel()`. Previously, notebook/lexical tool operations failed when VS Code focus was on the Cascade chat panel because the active-tab check returned nothing. The new method walks all registered webview panels and returns the first available one.
 - `resolveNotebookId` and `resolveLexicalId` in the MCP path similarly fall back to the document registry when the active-tab check returns no result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ## [Unreleased]
 
+## [0.0.17-alpha.adp1] - 2026-04-29
+
+### Added (April 2025)
+
+- **Windsurf / Cascade MCP Integration**: All 22 Datalayer tools are now accessible to Windsurf/Cascade via a local HTTP MCP (Model Context Protocol) server
+  - New file: `src/mcp/mcpServer.ts` — starts a stateless `StreamableHTTPServerTransport` server on `http://localhost:3333/mcp` (auto-scans 3333–3340 for a free port)
+  - Reuses the same `getCombinedOperations()` and `getAllToolDefinitionsAsync()` registry as the existing GitHub Copilot integration — no duplication
+  - `createNotebook` / `createLexical` default to cloud when authenticated, local otherwise (no VS Code Quick Pick prompts)
+  - Server startup failure is non-fatal: logged as a warning so extension activation is never blocked
+  - Configure Windsurf via `~/.codeium/windsurf/mcp_config.json` — see `src/mcp/README.md`
+  - New npm dependency: `@modelcontextprotocol/sdk@1.29.0` (externalized in webpack, whitelisted in `.vscodeignore`)
+
+### Fixed (April 2025)
+
+- **MCP tool execution when Cascade panel is focused**: `DocumentRegistry.getBestWebviewPanel()` added as a fallback to `getActiveWebviewPanel()`. Previously, notebook/lexical tool operations failed when VS Code focus was on the Cascade chat panel because the active-tab check returned nothing. The new method walks all registered webview panels and returns the first available one.
+- `resolveNotebookId` and `resolveLexicalId` in the MCP path similarly fall back to the document registry when the active-tab check returns no result.
+
+### Fixed (January 2025)
+
+
 ## [0.0.16] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to the Datalayer VS Code extension are documented here.
   - Configure Windsurf via `~/.codeium/windsurf/mcp_config.json` — see `src/mcp/README.md`
   - New npm dependency: `@modelcontextprotocol/sdk@1.29.0` (externalized in webpack, whitelisted in `.vscodeignore`)
 
+### Fixed (April 2025) — `0.0.16-alpha.3`
+
+- **`datalayer_getActiveDocument` required a lexical document**: The tool has `"lexical"` in its tags (correctly describing that it supports lexical documents), but `buildMcpExecutionContext` was reading that as "this tool needs a lexical document ID resolved" — calling `resolveLexicalId()` on every invocation and failing with `"No Lexical document is open"` when working on a plain `.ipynb` notebook. Fixed by adding an `isPrerequisiteTool` guard: tools tagged `"prerequisite"` now skip document ID resolution entirely, since they are orientation/discovery tools that should work regardless of what document type is open.
+
 ### Fixed (April 2025) — `0.0.16-alpha.2`
 
 - **Multi-notebook ambiguity**: Previously, when no Datalayer editor tab was focused (e.g. Cascade panel was active) and multiple notebooks were open, the MCP path always picked the first registered notebook regardless of what the user was working on. The new `lastUsed`-sorted `getByType()` and `startTabWatcher()` ensure the most recently focused or most recently used notebook is selected by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ### Fixed (April 2025) — `0.0.17-alpha.adp11`
 
-- **MathJax stretchy brackets now render in markdown**: LaTeX commands like `\underbrace`, `\overbrace`, and `\underbracket` now render correctly in notebook markdown cells. Previously these stretchy delimiters appeared blank because the MathJax Size fonts (`MJXTEX-S1..S4`) were never loaded. Fixed by importing `@jupyterlab/mathjax-extension/style/base.css` in the webview entry point, which webpack processes to emit the 22 MathJax WOFF font files and inject the required `@font-face` declarations at runtime.
+- **MathJax stretchy brackets now render in markdown**: LaTeX commands like `\underbrace`, `\overbrace`, and `\underbracket` now render correctly in notebook markdown cells. Previously these stretchy delimiters appeared blank because the MathJax Size fonts (`MJXTEX-S1..S4`) were never loaded. ~~Initially fixed by importing `@jupyterlab/mathjax-extension/style/base.css` in the webview entry point~~ — **superseded by the upstream fix** (`52fd432`): `webpack.config.js` now splits font files (`.eot|ttf|woff2?`) into a dedicated `asset/resource` rule so MathJax CHTML fonts are emitted as separate files rather than inlined; the CSS import and its `webview/global.d.ts` type stub have been removed.
 
 ### Fixed (April 2025) — `0.0.17-alpha.adp10`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Datalayer VS Code extension are documented here.
 
 ## [Unreleased]
 
+### Added (May 2025) — `0.0.17-alpha.adp12`
+
+- **`datalayer_batch` tool (Code Mode)**: New meta-tool that executes a sequence of Datalayer operations in a single MCP call, eliminating LLM round-trips between mechanical steps. Inspired by Cloudflare's Code Mode pattern.
+  - Accepts `operations: [{tool, params}]` — a JSON pipeline of any Datalayer tools.
+  - The LLM plans a complete multi-step workflow upfront (e.g. `readAllCells → insertCell → runCell → readCell`) and sends it once; the server executes all steps sequentially and returns an array of results.
+  - Top-level `notebook_uri` / `documentUri` are forwarded to every cell / block sub-operation, enabling the fast direct-URI resolution path.
+  - Upfront validation of all tool names before any execution; immediate error with list of valid names if any are unknown.
+  - `stopOnError` flag (default `true`) — set to `false` to run all steps and collect partial results even when a step fails.
+  - Registered directly in `buildMcpServer()` via closure (not through the standard definition→operation loop) so it has full access to `definitions`, `operations`, and `services` for per-sub-op `buildMcpExecutionContext` calls.
+  - `datalayer_batch` is skipped in the standard MCP registration loop to prevent double-registration.
+  - A lightweight stub `batchOperation` in `src/tools/operations/batch.ts` satisfies `validateToolDefinitions` and the VS Code Copilot tool path (returns a clear error directing callers to the MCP path).
+  - New files: `src/tools/definitions/batch.ts`, `src/tools/operations/batch.ts`.
+
+
 ### Added (April 2025) — `0.0.17-alpha.adp11`
 
 - **Cross-window notebook registry via `globalState`**: New `CrossWindowRegistry` class (`src/mcp/crossWindowRegistry.ts`) uses VS Code's `ExtensionContext.globalState` (shared across all windows) to broadcast each window's open notebooks and MCP port. Every 15 seconds the registry writes a heartbeat + current notebook list; entries older than 45 seconds are treated as stale (window closed). When an MCP tool call fails to find a notebook locally, it now checks `globalState` for other active windows and returns an informative error listing exactly which notebooks are open in other windows and on which port, guiding the user to switch to the correct Cascade session or reopen the notebook in the current window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ All notable changes to the Datalayer VS Code extension are documented here.
   - A lightweight stub `batchOperation` in `src/tools/operations/batch.ts` satisfies `validateToolDefinitions` and the VS Code Copilot tool path (returns a clear error directing callers to the MCP path).
   - New files: `src/tools/definitions/batch.ts`, `src/tools/operations/batch.ts`.
 
-
 ### Added (April 2025) — `0.0.17-alpha.adp11`
 
 - **Cross-window notebook registry via `globalState`**: New `CrossWindowRegistry` class (`src/mcp/crossWindowRegistry.ts`) uses VS Code's `ExtensionContext.globalState` (shared across all windows) to broadcast each window's open notebooks and MCP port. Every 15 seconds the registry writes a heartbeat + current notebook list; entries older than 45 seconds are treated as stale (window closed). When an MCP tool call fails to find a notebook locally, it now checks `globalState` for other active windows and returns an informative error listing exactly which notebooks are open in other windows and on which port, guiding the user to switch to the correct Cascade session or reopen the notebook in the current window.
@@ -29,6 +28,40 @@ All notable changes to the Datalayer VS Code extension are documented here.
 ### Fixed (April 2025) — `0.0.17-alpha.adp10`
 
 - **Multi-window MCP config now writes to the correct file**: `0.0.16-alpha.9` wrote a workspace-level `.windsurf/mcp.json`, but Windsurf **only** reads `~/.codeium/windsurf/mcp_config.json` — there is no workspace-level config override. The extension now updates the global `mcp_config.json` directly: it reads the existing file, patches only the `datalayer` entry with the claimed port, and writes it back, preserving all other servers. Windsurf hot-reloads the affected server automatically when the file changes (no manual refresh required). The workspace-level `.windsurf/mcp.json` is still written as a transparency artifact.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp9`
+
+- **Multi-window MCP port collision**: When multiple VS Code windows are open, each window's Datalayer extension claims a different port (3333–3340). Previously only the window on port 3333 was reachable. Fixed by writing `.windsurf/mcp.json` on startup (superseded by alpha.10 which correctly targets the global config).
+
+### Fixed (April 2025) — `0.0.17-alpha.adp8`
+
+- **Webview-not-ready race condition**: Even after the early `register()` fix in alpha.7, tool calls made while the Datalayer React app was still initialising would time out after 30 seconds (the webview panel existed in the registry but couldn't handle messages yet). Fixed by:
+  1. Adding `isWebviewReady: boolean` to `DocumentRegistryEntry` — set `false` on early registration, `true` when `handleReadyMessage` fires (i.e. the webview has sent its `"ready"` handshake).
+  2. Adding `markWebviewReady(documentUri)` to `DocumentRegistry`, called from `handleReadyMessage` in `notebookProvider.ts`.
+  3. Replacing `getBestWebviewPanel()` in the MCP executor with `getBestWebviewPanelWithStatus()`, which now throws a precise `"notebook still loading, please wait and retry"` error instead of hitting the 30-second timeout.
+  4. `getBestWebviewPanel()` now prefers ready panels over not-yet-ready panels.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp7`
+
+- **Race condition: registry empty when webview hasn't loaded yet** (root cause of most "no notebook found" errors): The `documentRegistry.register()` call in `notebookProvider.ts` was inside `handleReadyMessage()`, which is only triggered after the Datalayer webview React app finishes loading and sends a `"ready"` message. This takes several seconds. Any MCP tool call made before that point found an empty registry and failed — even though the notebook was visibly open in the Datalayer editor. Fixed by adding an early `register()` call directly in `resolveCustomEditor()` (immediately after the webview HTML is set), before any async work or message-handler setup.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp6`
+
+- **Native VS Code notebook viewer detection**: When an `.ipynb` file is open in the native VS Code notebook viewer instead of the Datalayer custom editor, MCP tools previously returned a generic "No Datalayer notebook is open" error. The server now scans all open tabs, detects notebooks in the native viewer, fires a VS Code warning notification with a **"Reopen in Datalayer Editor"** action button, and throws a precise, actionable error message. Clicking the notification button automatically reopens the file in the correct editor.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp5`
+
+- **`datalayer_listKernels`, `datalayer_selectKernel`, and `datalayer_executeCode` incorrectly required a lexical document**: `buildMcpExecutionContext` used `tags.includes("lexical")` as the discriminator for `needsBlockDocument`, causing these cross-domain tools to fail with `"No Lexical document is open"` when no `.dlex` file was open. Fixed by switching to `tags.includes("block") || tags.includes("blocks")`. Every actual block operation tool carries one of these tags; no cross-domain tool does.
+
+### Added (April 2025) — `0.0.17-alpha.adp4`
+
+- **`datalayer_listOpenDocuments` tool**: New VS Code-specific tool that returns every Jupyter notebook and Datalayer lexical document currently open in the Datalayer editor, sorted by most-recently-used first. Returns `uri`, `filename`, `type`, `rank`, and `mostRecent` for each document.
+
+- **`notebook_uri` parameter on all notebook cell tools**: All six notebook cell tools (`readAllCells`, `readCell`, `insertCell`, `updateCell`, `deleteCells`, `runCell`) now expose `notebook_uri` as an optional input parameter in their MCP schema. Cascade can now target any open notebook by URI rather than relying on whichever notebook happens to be focused in VS Code.
+
+### Fixed (April 2025) — `0.0.17-alpha.adp3`
+
+- **`datalayer_getActiveDocument` required a lexical document**: The tool has `"lexical"` in its tags (correctly describing that it supports lexical documents), but `buildMcpExecutionContext` was reading that as "this tool needs a lexical document ID resolved" — calling `resolveLexicalId()` on every invocation and failing with `"No Lexical document is open"` when working on a plain `.ipynb` notebook. Fixed by adding an `isPrerequisiteTool` guard: tools tagged `"prerequisite"` now skip document ID resolution entirely, since they are orientation/discovery tools that should work regardless of what document type is open.
 
 ### Added (April 2025) — `0.0.17-alpha.adp2`
 
@@ -52,49 +85,6 @@ All notable changes to the Datalayer VS Code extension are documented here.
   - Server startup failure is non-fatal: logged as a warning so extension activation is never blocked
   - Configure Windsurf via `~/.codeium/windsurf/mcp_config.json` — see `src/mcp/README.md`
   - New npm dependency: `@modelcontextprotocol/sdk@1.29.0` (externalized in webpack, whitelisted in `.vscodeignore`)
-
-### Fixed (April 2025) — `0.0.16-alpha.9`
-
-- **Multi-window MCP port collision**: When multiple VS Code windows are open, each window's Datalayer extension claims a different port (3333–3340). Previously only the window on port 3333 was reachable. Fixed by writing `.windsurf/mcp.json` on startup (superseded by alpha.10 which correctly targets the global config).
-
-### Fixed (April 2025) — `0.0.16-alpha.8`
-
-- **Webview-not-ready race condition**: Even after the early `register()` fix in alpha.7, tool calls made while the Datalayer React app was still initialising would time out after 30 seconds (the webview panel existed in the registry but couldn't handle messages yet). Fixed by:
-  1. Adding `isWebviewReady: boolean` to `DocumentRegistryEntry` — set `false` on early registration, `true` when `handleReadyMessage` fires (i.e. the webview has sent its `"ready"` handshake).
-  2. Adding `markWebviewReady(documentUri)` to `DocumentRegistry`, called from `handleReadyMessage` in `notebookProvider.ts`.
-  3. Replacing `getBestWebviewPanel()` in the MCP executor with `getBestWebviewPanelWithStatus()`, which now throws a precise `"notebook still loading, please wait and retry"` error instead of hitting the 30-second timeout.
-  4. `getBestWebviewPanel()` now prefers ready panels over not-yet-ready panels.
-
-### Fixed (April 2025) — `0.0.16-alpha.7`
-
-- **Race condition: registry empty when webview hasn't loaded yet** (root cause of most "no notebook found" errors): The `documentRegistry.register()` call in `notebookProvider.ts` was inside `handleReadyMessage()`, which is only triggered after the Datalayer webview React app finishes loading and sends a `"ready"` message. This takes several seconds. Any MCP tool call made before that point found an empty registry and failed — even though the notebook was visibly open in the Datalayer editor. Fixed by adding an early `register()` call directly in `resolveCustomEditor()` (immediately after the webview HTML is set), before any async work or message-handler setup.
-
-### Fixed (April 2025) — `0.0.16-alpha.6`
-
-- **Native VS Code notebook viewer detection**: When an `.ipynb` file is open in the native VS Code notebook viewer instead of the Datalayer custom editor, MCP tools previously returned a generic "No Datalayer notebook is open" error. The server now scans all open tabs, detects notebooks in the native viewer, fires a VS Code warning notification with a **"Reopen in Datalayer Editor"** action button, and throws a precise, actionable error message. Clicking the notification button automatically reopens the file in the correct editor.
-
-### Fixed (April 2025) — `0.0.16-alpha.5`
-
-- **`datalayer_listKernels`, `datalayer_selectKernel`, and `datalayer_executeCode` incorrectly required a lexical document**: `buildMcpExecutionContext` used `tags.includes("lexical")` as the discriminator for `needsBlockDocument`, causing these cross-domain tools to fail with `"No Lexical document is open"` when no `.dlex` file was open. Fixed by switching to `tags.includes("block") || tags.includes("blocks")`. Every actual block operation tool carries one of these tags; no cross-domain tool does.
-
-### Added (April 2025) — `0.0.16-alpha.4`
-
-- **`datalayer_listOpenDocuments` tool**: New VS Code-specific tool that returns every Jupyter notebook and Datalayer lexical document currently open in the Datalayer editor, sorted by most-recently-used first. Returns `uri`, `filename`, `type`, `rank`, and `mostRecent` for each document.
-
-- **`notebook_uri` parameter on all notebook cell tools**: All six notebook cell tools (`readAllCells`, `readCell`, `insertCell`, `updateCell`, `deleteCells`, `runCell`) now expose `notebook_uri` as an optional input parameter in their MCP schema. Cascade can now target any open notebook by URI rather than relying on whichever notebook happens to be focused in VS Code.
-
-### Fixed (April 2025) — `0.0.16-alpha.3`
-
-- **`datalayer_getActiveDocument` required a lexical document**: The tool has `"lexical"` in its tags (correctly describing that it supports lexical documents), but `buildMcpExecutionContext` was reading that as "this tool needs a lexical document ID resolved" — calling `resolveLexicalId()` on every invocation and failing with `"No Lexical document is open"` when working on a plain `.ipynb` notebook. Fixed by adding an `isPrerequisiteTool` guard: tools tagged `"prerequisite"` now skip document ID resolution entirely, since they are orientation/discovery tools that should work regardless of what document type is open.
-
-### Fixed (April 2025) — `0.0.16-alpha.2`
-
-- **Multi-notebook ambiguity**: Previously, when no Datalayer editor tab was focused (e.g. Cascade panel was active) and multiple notebooks were open, the MCP path always picked the first registered notebook regardless of what the user was working on. The new `lastUsed`-sorted `getByType()` and `startTabWatcher()` ensure the most recently focused or most recently used notebook is selected by default.
-
-### Fixed (April 2025) — `0.0.16-alpha.1`
-
-- **MCP tool execution when Cascade panel is focused**: `DocumentRegistry.getBestWebviewPanel()` added as a fallback to `getActiveWebviewPanel()`. Previously, notebook/lexical tool operations failed when VS Code focus was on the Cascade chat panel because the active-tab check returned nothing. The new method walks all registered webview panels and returns the first available one.
-- `resolveNotebookId` and `resolveLexicalId` in the MCP path similarly fall back to the document registry when the active-tab check returns no result.
 
 ### Fixed (January 2025)
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
 - **Command palette integration** - All features accessible via `Ctrl+Shift+P`
 - **AI assistant integration** - Use natural language to create notebooks, insert cells, execute code, and manage documents:
   - **GitHub Copilot** — 22 tools registered via VS Code's Language Model Tools API
-  - **Windsurf / Cascade** — same 22 tools exposed over a local MCP HTTP server at `http://localhost:3333/mcp`
+  - **Windsurf / Cascade** — same 22 tools exposed over a local MCP HTTP server at `http://localhost:3333/mcp`; intelligent multi-notebook selection automatically targets the most recently focused document
 
 ## 💡 Common Questions
 
@@ -207,7 +207,19 @@ Open settings (`Ctrl+,` / `Cmd+,`) and search "Datalayer":
 
 ## Recent Updates
 
-### Windsurf / Cascade MCP Integration (April 2025)
+### Intelligent Notebook Selection for Cascade (`0.0.16-alpha.2`)
+
+When multiple Datalayer notebooks are open, MCP tool calls now target the correct one automatically:
+
+- **Tab focus tracking** — clicking a notebook tab in VS Code updates its recency so Cascade targets it by default
+- **MCP call tracking** — each tool call reinforces the last-used document
+- **LLM-assisted disambiguation** — `datalayer_getActiveDocument` now returns a ranked list of all open documents so Cascade can match by filename or topic from the user's request, and ask when genuinely ambiguous
+
+### Windsurf Skill (`0.0.16-alpha.2`)
+
+A Windsurf skill (`SKILL.md` + `tool-reference.md`) is bundled in `.windsurf/skills/datalayer-mcp/`. It establishes the Datalayer MCP server as the **required** interface for all Jupyter notebook work — prohibiting direct `.ipynb` file manipulation — and provides Cascade with tool reference, workflow recipes, error patterns, and notebook selection guidance.
+
+### Windsurf / Cascade MCP Integration (`0.0.16-alpha.1`)
 
 All 22 Datalayer tools are now available to [Windsurf](https://windsurf.com) / Cascade via a local MCP HTTP server that starts automatically with the extension.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ Open settings (`Ctrl+,` / `Cmd+,`) and search "Datalayer":
 
 ## Recent Updates
 
+### `datalayer_batch` Tool — Code Mode (`0.0.16-alpha.12`)
+
+New meta-tool that executes a sequence of Datalayer operations in a single MCP call, eliminating LLM round-trips between mechanical steps. Inspired by Cloudflare's Code Mode pattern.
+
+Instead of:
+```
+LLM → readAllCells → LLM → insertCell → LLM → runCell → LLM → readCell
+```
+
+Cascade can now plan the whole workflow upfront and send it once:
+```json
+datalayer_batch({
+  "operations": [
+    { "tool": "datalayer_readAllCells", "params": {} },
+    { "tool": "datalayer_insertCell",   "params": { "type": "code", "source": "print(42)", "index": 5 } },
+    { "tool": "datalayer_runCell",      "params": { "index": 5 } },
+    { "tool": "datalayer_readCell",     "params": { "index": 5 } }
+  ],
+  "notebook_uri": "..."
+})
+```
+
+The server executes all steps in order and returns an array of results. `stopOnError` (default `true`) halts on the first failure; set to `false` to collect partial results across all steps.
+
 ### MathJax Stretchy Brackets Fixed (`0.0.16-alpha.11`)
 
 LaTeX commands like `\underbrace`, `\overbrace`, and `\underbracket` now render correctly in notebook markdown cells. Previously these stretchy delimiters appeared blank because the MathJax Size fonts were never loaded. Fixed by importing the MathJax extension's font CSS in the webview entry point.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@
 - **Rich status indicators** - Connection status and runtime info in status bar
 - **Command palette integration** - All features accessible via `Ctrl+Shift+P`
 - **AI assistant integration** - Use natural language to create notebooks, insert cells, execute code, and manage documents:
-  - **GitHub Copilot** — 22 tools registered via VS Code's Language Model Tools API
-  - **Windsurf / Cascade** — same 22 tools exposed over a local MCP HTTP server at `http://localhost:3333/mcp`; intelligent multi-notebook selection automatically targets the most recently focused document
+  - **GitHub Copilot** — 23 tools registered via VS Code's Language Model Tools API
+  - **Windsurf / Cascade** — same 23 tools exposed over a local MCP HTTP server at `http://localhost:3333/mcp`; intelligent multi-notebook selection automatically targets the most recently focused document; explicit notebook targeting via `datalayer_listOpenDocuments` + `notebook_uri` parameter
 
 ## 💡 Common Questions
 
@@ -214,6 +214,40 @@ When multiple Datalayer notebooks are open, MCP tool calls now target the correc
 - **Tab focus tracking** — clicking a notebook tab in VS Code updates its recency so Cascade targets it by default
 - **MCP call tracking** — each tool call reinforces the last-used document
 - **LLM-assisted disambiguation** — `datalayer_getActiveDocument` now returns a ranked list of all open documents so Cascade can match by filename or topic from the user's request, and ask when genuinely ambiguous
+
+### Multi-Window MCP Auto-Configuration (`0.0.16-alpha.10`)
+
+When multiple VS Code windows are open (e.g. one for the extension itself, one for a data science project), each window's Datalayer extension claims a different MCP port (3333–3340). Previously only the window on port 3333 worked because Windsurf's global config hardcoded that port.
+
+Now, on every extension activation, the extension patches `~/.codeium/windsurf/mcp_config.json` directly — updating only the `datalayer` entry with the current window's port while preserving all other servers. Windsurf hot-reloads the affected entry automatically when the file changes, so no manual refresh is needed. The most-recently-activated window always wins. A workspace-level `.windsurf/mcp.json` is also written as a transparency artifact.
+
+### `datalayer_listOpenDocuments` Tool + `notebook_uri` Parameter (`0.0.16-alpha.4`)
+
+- **New `datalayer_listOpenDocuments` tool** — returns all open Datalayer notebooks and lexical docs sorted by most-recently-used, with `uri`, `filename`, `type`, and `rank` fields.
+- **`notebook_uri` parameter on all cell tools** — `readAllCells`, `readCell`, `insertCell`, `updateCell`, `deleteCells`, `runCell` now accept an optional `notebook_uri` so Cascade can target any open notebook by URI without relying on VS Code focus state.
+
+### Tool Routing Fix: `listKernels`/`selectKernel`/`executeCode` (`0.0.16-alpha.5`)
+
+These tools were incorrectly requiring a lexical document open. `buildMcpExecutionContext` used `tags.includes("lexical")` as the `needsBlockDocument` discriminator, but `"lexical"` is shared by cross-domain tools. Switched to `tags.includes("block") || tags.includes("blocks")` — every actual block tool carries one of these; no cross-domain tool does.
+
+### Notebook Loading Race Conditions Fixed (`0.0.16-alpha.7` + `0.0.16-alpha.8`)
+
+Two race conditions that caused MCP tools to fail even when a notebook was open in the Datalayer editor have been resolved:
+
+- **alpha.7** — `documentRegistry.register()` was only called after the webview's `"ready"` message (several seconds after opening). MCP tool calls during that window found an empty registry. Fixed by registering immediately in `resolveCustomEditor()`.
+- **alpha.8** — Even after the registry was populated, tool calls during webview initialization would time out after 30 s. Added `isWebviewReady` tracking and `getBestWebviewPanelWithStatus()` so the MCP executor now returns a clear `"notebook still loading, please retry"` error instead of silently timing out.
+
+### Native Notebook Viewer Detection (`0.0.16-alpha.6`)
+
+When an `.ipynb` file is open in the native VS Code notebook viewer instead of the Datalayer custom editor, MCP tools now detect this automatically. A VS Code notification appears with a **"Reopen in Datalayer Editor"** button that reopens the file in the correct editor with one click. The error message returned to Cascade is also precise and actionable: `right-click → Open With… → Datalayer Notebook Editor`.
+
+### MCP Tool Routing Fix (`0.0.16-alpha.5`)
+
+Fixed a systematic routing bug where cross-domain tools (`datalayer_listKernels`, `datalayer_selectKernel`, `datalayer_executeCode`) failed with *"No Lexical document is open"* any time a `.dlex` file was not open. The MCP server was using `"lexical"` tag presence as the discriminator for "needs a lexical document ID", but `"lexical"` is a domain descriptor shared by many tools. Changed to use `"block"` / `"blocks"` tag instead, which precisely identifies actual block-operation tools.
+
+### Explicit Notebook Targeting (`0.0.16-alpha.4`)
+
+All notebook cell tools (`readAllCells`, `updateCell`, `runCell`, etc.) now expose an optional `notebook_uri` parameter. Combined with the new `datalayer_listOpenDocuments` tool (which returns all open notebooks sorted by recency with their URIs), Cascade can now target any open notebook explicitly without requiring it to be the active VS Code tab. This resolves workflows where multiple notebooks are open and the AI needs to work on a specific one.
 
 ### Windsurf Skill (`0.0.16-alpha.2`)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@
 - **Native local execution** - Direct ZMQ kernel communication without Jupyter server
 - **Rich status indicators** - Connection status and runtime info in status bar
 - **Command palette integration** - All features accessible via `Ctrl+Shift+P`
-- **GitHub Copilot integration** - Use natural language to create notebooks and insert cells (e.g., "Create a local notebook and add a plot")
+- **AI assistant integration** - Use natural language to create notebooks, insert cells, execute code, and manage documents:
+  - **GitHub Copilot** — 22 tools registered via VS Code's Language Model Tools API
+  - **Windsurf / Cascade** — same 22 tools exposed over a local MCP HTTP server at `http://localhost:3333/mcp`
 
 ## 💡 Common Questions
 
@@ -204,6 +206,24 @@ Open settings (`Ctrl+,` / `Cmd+,`) and search "Datalayer":
 - `datalayer.logging.enablePerformanceMonitoring` - Track performance (default: false)
 
 ## Recent Updates
+
+### Windsurf / Cascade MCP Integration (April 2025)
+
+All 22 Datalayer tools are now available to [Windsurf](https://windsurf.com) / Cascade via a local MCP HTTP server that starts automatically with the extension.
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "datalayer": {
+      "serverUrl": "http://localhost:3333/mcp"
+    }
+  }
+}
+```
+
+The actual port is logged to the Datalayer output channel on activation (`MCP HTTP server listening on http://127.0.0.1:<port>/mcp`).
 
 ### Runtime Controller Improvements
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ Open settings (`Ctrl+,` / `Cmd+,`) and search "Datalayer":
 
 ## Recent Updates
 
+### MathJax Stretchy Brackets Fixed (`0.0.16-alpha.11`)
+
+LaTeX commands like `\underbrace`, `\overbrace`, and `\underbracket` now render correctly in notebook markdown cells. Previously these stretchy delimiters appeared blank because the MathJax Size fonts were never loaded. Fixed by importing the MathJax extension's font CSS in the webview entry point.
+
+### Cross-Window Notebook Registry (`0.0.16-alpha.11`)
+
+When an MCP tool call fails to find a notebook locally, it now checks for other active VS Code windows and returns an informative error listing which notebooks are open in other windows and on which port, guiding you to switch to the correct Cascade session or reopen the notebook in the current window.
+
 ### Intelligent Notebook Selection for Cascade (`0.0.16-alpha.2`)
 
 When multiple Datalayer notebooks are open, MCP tool calls now target the correct one automatically:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@lumino/coreutils": "^2.1.1",
         "@lumino/disposable": "^2.1.1",
         "@lumino/signaling": "^2.1.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@nteract/messaging": "^7.0.20",
         "@primer/react": "^37.19.0",
         "@primer/react-brand": "^0.58.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@lumino/coreutils": "^2.1.1",
     "@lumino/disposable": "^2.1.1",
     "@lumino/signaling": "^2.1.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nteract/messaging": "^7.0.20",
     "@primer/react": "^37.19.0",
     "@primer/react-brand": "^0.58.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Datalayer",
   "displayName": "Datalayer",
   "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17-alpha.adp11",
+  "version": "0.0.17-alpha.adp12",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Datalayer",
   "displayName": "Datalayer",
   "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17-alpha.adp2",
+  "version": "0.0.17-alpha.adp3",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Datalayer",
   "displayName": "Datalayer",
   "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17-alpha.adp10",
+  "version": "0.0.17-alpha.adp11",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Datalayer",
   "displayName": "Datalayer",
   "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17-alpha.adp1",
+  "version": "0.0.17-alpha.adp2",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "datalayer-jupyter-vscode",
   "publisher": "Datalayer",
   "displayName": "Datalayer",
-  "description": "✨ 🤖 Managed AI Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17",
+  "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
+  "version": "0.0.17-alpha.adp1",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "Datalayer",
   "displayName": "Datalayer",
   "description": "✨ 🤖 Autonomous Agents for Data Analysis. LLM are bad at data — we fix that.",
-  "version": "0.0.17-alpha.adp3",
+  "version": "0.0.17-alpha.adp10",
   "cache_version": "2",
   "icon": "images/datalayer-logo.png",
   "categories": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,6 +309,28 @@ export async function activate(
       );
     });
 
+    await runOptionalActivationStep(
+      "Starting MCP HTTP server for Windsurf/Cascade",
+      async () => {
+        const { startMcpServer } = await import("./mcp/mcpServer");
+        const mcpHttpServer = await startMcpServer(context, services!, ui!);
+        context.subscriptions.push({
+          dispose: () => {
+            mcpHttpServer.close();
+          },
+        });
+        activationTimer.checkpoint("mcp_http_server_started");
+      },
+      (err) => {
+        logger.warn(
+          "MCP HTTP server failed to start (Windsurf/Cascade tools unavailable)",
+          {
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+      },
+    );
+
     await runActivationStep("Activating Python extension", async () => {
       logger.debug(
         "Proactively activating Python extension for kernel discovery",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -319,6 +319,11 @@ export async function activate(
             mcpHttpServer.close();
           },
         });
+        // Keep lastUsed current when the user manually switches notebook tabs,
+        // so MCP tool calls without an explicit notebook_uri prefer the focused one.
+        context.subscriptions.push(
+          services!.documentRegistry.startTabWatcher(),
+        );
         activationTimer.checkpoint("mcp_http_server_started");
       },
       (err) => {

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,23 @@
+# src/mcp
+
+HTTP MCP (Model Context Protocol) server that exposes all Datalayer tools to Windsurf/Cascade.
+
+## Files
+
+- **`mcpServer.ts`** — `startMcpServer()` entry point. Creates an HTTP server on `localhost:3333` (or the next available port) that implements the MCP Streamable HTTP transport. Registers all 22 Datalayer tools using the same `getCombinedOperations()` registry that the VS Code LM adapter uses for Copilot. Differences from the Copilot path: no VS Code Quick Pick dialogs; `createNotebook`/`createLexical` default to cloud when authenticated, local otherwise.
+
+## Windsurf Configuration
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "datalayer": {
+      "serverUrl": "http://localhost:3333/mcp"
+    }
+  }
+}
+```
+
+The actual port is logged to the Datalayer output channel on activation (search for "MCP HTTP server").

--- a/src/mcp/crossWindowRegistry.ts
+++ b/src/mcp/crossWindowRegistry.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * Cross-window notebook registry using VS Code's globalState.
+ *
+ * Each VS Code window running the Datalayer extension writes its open
+ * notebooks and MCP server port into the shared globalState store. When
+ * an MCP tool call fails to find a notebook locally, the executor queries
+ * this registry to detect whether the requested document is open in a
+ * *different* VS Code window — and returns an actionable error instead of
+ * a generic "no notebook found" message.
+ *
+ * @module mcp/crossWindowRegistry
+ */
+
+import * as vscode from "vscode";
+
+import type { DocumentRegistry } from "../services/documents/documentRegistry";
+
+/** globalState key used to share the registry across windows. */
+const GLOBAL_STATE_KEY = "datalayer.mcp.windowRegistry";
+
+/** How often (ms) each window refreshes its heartbeat + notebook list. */
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * How old (ms) a globalState entry can be before it is considered stale
+ * (i.e. that window has closed or the extension deactivated without cleaning up).
+ * Set to 3× the heartbeat interval for tolerance.
+ */
+const HEARTBEAT_TTL_MS = 45_000;
+
+/** A single notebook or lexical document entry. */
+interface DocEntry {
+  /** VS Code document URI string. */
+  uri: string;
+  /** Filename (last path segment). */
+  filename: string;
+  /** Document type. */
+  type: "notebook" | "lexical";
+}
+
+/** Registry entry written by each active VS Code window. */
+interface WindowEntry {
+  /** MCP HTTP server port this window is listening on. */
+  port: number;
+  /** Unique ID for this window instance (port + startup timestamp). */
+  windowId: string;
+  /** All open notebooks and lexical docs in this window's Datalayer editor. */
+  documents: DocEntry[];
+  /** Unix timestamp (ms) of the last heartbeat write. */
+  heartbeat: number;
+}
+
+/** Shape of the full cross-window registry stored in globalState. */
+type Registry = Record<string, WindowEntry>;
+
+/**
+ * Manages cross-window document visibility via VS Code `globalState`.
+ *
+ * Usage:
+ * ```typescript
+ * const cwr = new CrossWindowRegistry(context, port, documentRegistry);
+ * cwr.start(); // begin heartbeat
+ * context.subscriptions.push({ dispose: () => cwr.dispose() });
+ * ```
+ */
+export class CrossWindowRegistry {
+  private readonly windowId: string;
+  private heartbeatTimer?: ReturnType<typeof setInterval>;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly port: number,
+    private readonly documentRegistry: DocumentRegistry,
+  ) {
+    this.windowId = `${port}-${Date.now()}`;
+  }
+
+  /**
+   * Register this window in globalState and start the heartbeat interval.
+   * Call once immediately after the MCP server binds its port.
+   */
+  start(): void {
+    this.sync();
+    this.heartbeatTimer = setInterval(() => this.sync(), HEARTBEAT_INTERVAL_MS);
+  }
+
+  /**
+   * Remove this window's entry from globalState and stop the heartbeat.
+   * Call from the extension's deactivation / subscription disposal.
+   */
+  dispose(): void {
+    if (this.heartbeatTimer !== undefined) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+    const registry = this.readRegistry();
+    delete registry[this.windowId];
+    void this.context.globalState.update(GLOBAL_STATE_KEY, registry);
+  }
+
+  /**
+   * Check whether a notebook (by URI or filename) is open in a *different*
+   * VS Code window. Returns the first match found, or `undefined` if the
+   * document is not registered in any other active window.
+   *
+   * @param uriOrFilename - Full URI string or bare filename to search for.
+   */
+  findInOtherWindows(
+    uriOrFilename: string,
+  ): { port: number; filename: string; uri: string } | undefined {
+    const registry = this.readRegistry();
+    const now = Date.now();
+
+    for (const [wid, entry] of Object.entries(registry)) {
+      if (wid === this.windowId) {
+        continue; // don't report our own window
+      }
+      if (now - entry.heartbeat > HEARTBEAT_TTL_MS) {
+        continue; // stale — window likely closed
+      }
+      for (const doc of entry.documents) {
+        if (
+          doc.uri === uriOrFilename ||
+          doc.filename === uriOrFilename ||
+          doc.uri.endsWith(`/${uriOrFilename}`)
+        ) {
+          return { port: entry.port, filename: doc.filename, uri: doc.uri };
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns a summary of all documents open in OTHER active windows.
+   * Useful for building informational error messages when no local notebook
+   * is found and the user might be confused about which window to use.
+   */
+  getOtherWindowsSummary(): Array<{
+    port: number;
+    documents: DocEntry[];
+  }> {
+    const registry = this.readRegistry();
+    const now = Date.now();
+    const result: Array<{ port: number; documents: DocEntry[] }> = [];
+
+    for (const [wid, entry] of Object.entries(registry)) {
+      if (wid === this.windowId) {
+        continue;
+      }
+      if (now - entry.heartbeat > HEARTBEAT_TTL_MS) {
+        continue;
+      }
+      if (entry.documents.length > 0) {
+        result.push({ port: entry.port, documents: entry.documents });
+      }
+    }
+    return result;
+  }
+
+  // ── private ───────────────────────────────────────────────────────────────
+
+  /** Write/refresh this window's entry in globalState. */
+  private sync(): void {
+    const documents: DocEntry[] = [
+      ...this.documentRegistry.getByType("notebook").map((e) => ({
+        uri: e.documentUri,
+        filename: e.documentUri.split("/").pop() ?? e.documentUri,
+        type: "notebook" as const,
+      })),
+      ...this.documentRegistry.getByType("lexical").map((e) => ({
+        uri: e.documentUri,
+        filename: e.documentUri.split("/").pop() ?? e.documentUri,
+        type: "lexical" as const,
+      })),
+    ];
+
+    const registry = this.readRegistry();
+    registry[this.windowId] = {
+      port: this.port,
+      windowId: this.windowId,
+      documents,
+      heartbeat: Date.now(),
+    };
+    void this.context.globalState.update(GLOBAL_STATE_KEY, registry);
+  }
+
+  /** Read the current registry from globalState. */
+  private readRegistry(): Registry {
+    return this.context.globalState.get<Registry>(GLOBAL_STATE_KEY) ?? {};
+  }
+}

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -36,6 +36,13 @@ import {
   getActiveDatalayerNotebook,
   validateDatalayerNotebook,
 } from "../utils/notebookValidation";
+import { CrossWindowRegistry } from "./crossWindowRegistry";
+
+/**
+ * Cross-window registry instance for this window.
+ * Set once in startMcpServer(); read from the error path in the MCP executor.
+ */
+let crossWindowRegistry: CrossWindowRegistry | undefined;
 
 /** Default MCP HTTP server port. */
 const MCP_DEFAULT_PORT = 3333;
@@ -395,6 +402,21 @@ async function buildMcpExecutionContext(
             `"${names}" is open in the native VS Code notebook viewer, not the Datalayer editor. ` +
               `Right-click the file in the Explorer → "Open With…" → "Datalayer Notebook Editor", ` +
               `then retry. (A notification with a one-click button has also appeared in VS Code.)`,
+          );
+        }
+        // Check whether the notebook is open in another VS Code window.
+        const otherWindows = crossWindowRegistry?.getOtherWindowsSummary() ?? [];
+        if (otherWindows.length > 0) {
+          const lines = otherWindows.map(
+            (w) =>
+              `  • Port ${w.port}: ${w.documents.map((d) => d.filename).join(", ") || "(no documents open)"}`,
+          );
+          throw new Error(
+            `No Datalayer notebook is open in THIS window's editor, but notebooks are open in other VS Code windows:\n` +
+              lines.join("\n") +
+              `\n\nTo fix: switch to the VS Code window with the notebook you want to use — ` +
+              `Cascade there will connect to that window's MCP server automatically. ` +
+              `Or open the notebook in this window via right-click → "Open With…" → "Datalayer Notebook Editor".`,
           );
         }
         throw new Error(
@@ -789,7 +811,7 @@ function buildMcpServer(
  * Each POST to /mcp spins up a fresh McpServer+transport pair so no session
  * state leaks between Cascade requests.
  *
- * @param _context - VS Code extension context (reserved for future use).
+ * @param context - VS Code extension context (used for globalState cross-window registry).
  * @param services - Initialized service container providing auth and VS Code APIs.
  * @param _ui - Extension UI components (reserved for future use).
  *
@@ -798,7 +820,7 @@ function buildMcpServer(
  * @throws Error when no port in the default range is available.
  */
 export async function startMcpServer(
-  _context: import("vscode").ExtensionContext,
+  context: import("vscode").ExtensionContext,
   services: ServiceContainer,
   _ui: ExtensionUI,
 ): Promise<http.Server> {
@@ -883,6 +905,20 @@ export async function startMcpServer(
   // with this window's port. Windsurf hot-reloads the global config on change,
   // so no manual refresh is needed after this write.
   await writeMcpConfig(port, services);
+
+  // Start cross-window registry so other windows (and their Cascade sessions)
+  // can see which notebooks are open here and receive helpful error messages
+  // when they reference a document that lives in a different window.
+  crossWindowRegistry = new CrossWindowRegistry(
+    context,
+    port,
+    services.documentRegistry,
+  );
+  crossWindowRegistry.start();
+  httpServer.on("close", () => {
+    crossWindowRegistry?.dispose();
+    crossWindowRegistry = undefined;
+  });
 
   return httpServer;
 }

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -297,6 +297,36 @@ async function resolveLexicalId(
 }
 
 /**
+ * Returns URIs of .ipynb files currently open in the native VS Code notebook
+ * viewer (i.e. NOT in the Datalayer custom editor). Used to produce actionable
+ * error messages and offer a one-click reopen when MCP tools can't find a
+ * Datalayer webview.
+ *
+ * @returns Array of URIs for notebooks open in native VS Code viewer.
+ */
+function detectNativeNotebookTabs(): vscode.Uri[] {
+  const datalayerViewType = "datalayer.jupyter-notebook";
+  const found: vscode.Uri[] = [];
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      // TabInputNotebook → native VS Code notebook viewer
+      if (tab.input instanceof vscode.TabInputNotebook) {
+        found.push((tab.input as vscode.TabInputNotebook).uri);
+      }
+      // TabInputCustom with a non-Datalayer viewType and .ipynb extension
+      if (
+        tab.input instanceof vscode.TabInputCustom &&
+        (tab.input as vscode.TabInputCustom).viewType !== datalayerViewType &&
+        (tab.input as vscode.TabInputCustom).uri.path.endsWith(".ipynb")
+      ) {
+        found.push((tab.input as vscode.TabInputCustom).uri);
+      }
+    }
+  }
+  return found;
+}
+
+/**
  * Builds a ToolExecutionContext for use in the MCP handler.
  *
  * Mirrors VSCodeToolAdapter.buildExecutionContext but without VS Code Quick Pick
@@ -322,7 +352,13 @@ async function buildMcpExecutionContext(
 
   const isPrerequisiteTool = definition.tags?.includes("prerequisite");
   const needsCellDocument = !isPrerequisiteTool && definition.tags?.includes("cell");
-  const needsBlockDocument = !isPrerequisiteTool && definition.tags?.includes("lexical");
+  // Use "block"/"blocks" as the discriminator, NOT "lexical". The "lexical" tag is a
+  // domain descriptor shared by cross-domain tools (listKernels, selectKernel,
+  // executeCode) that don't need a lexical document ID. Every actual block operation
+  // tool carries "block" or "blocks" in its tags; none of the cross-domain tools do.
+  const needsBlockDocument =
+    !isPrerequisiteTool &&
+    (definition.tags?.includes("block") || definition.tags?.includes("blocks"));
   const isCreateOperation = definition.tags?.includes("create");
 
   // Build the webview executor — same postMessage bridge as Copilot path.
@@ -331,13 +367,48 @@ async function buildMcpExecutionContext(
       // Use getBestWebviewPanel() rather than getActiveWebviewPanel() so that
       // operations succeed even when VS Code focus is on the Cascade chat panel
       // instead of the notebook tab.
-      const webviewPanel = services.documentRegistry.getBestWebviewPanel();
-      if (!webviewPanel) {
+      const panelStatus = services.documentRegistry.getBestWebviewPanelWithStatus();
+      if (!panelStatus) {
+        // Detect .ipynb files open in the native VS Code notebook viewer.
+        // When found, offer a one-click path to reopen in the Datalayer editor.
+        const nativeNotebooks = detectNativeNotebookTabs();
+        if (nativeNotebooks.length > 0) {
+          const names = nativeNotebooks.map((u) => u.path.split("/").pop()).join(", ");
+          // Fire-and-forget notification with an action button — don't block the error.
+          vscode.window
+            .showWarningMessage(
+              `"${names}" is open in the native VS Code viewer. Reopen it in the Datalayer Notebook Editor for MCP tools to work.`,
+              "Reopen in Datalayer Editor",
+            )
+            .then((choice) => {
+              if (choice === "Reopen in Datalayer Editor") {
+                for (const uri of nativeNotebooks) {
+                  vscode.commands.executeCommand(
+                    "vscode.openWith",
+                    uri,
+                    "datalayer.jupyter-notebook",
+                  );
+                }
+              }
+            });
+          throw new Error(
+            `"${names}" is open in the native VS Code notebook viewer, not the Datalayer editor. ` +
+              `Right-click the file in the Explorer → "Open With…" → "Datalayer Notebook Editor", ` +
+              `then retry. (A notification with a one-click button has also appeared in VS Code.)`,
+          );
+        }
         throw new Error(
-          `No Datalayer notebook or lexical document is open. ` +
-            `Please open a Datalayer notebook or .dlex file, then retry.`,
+          `No notebook is open in the Datalayer editor. ` +
+            `Right-click an .ipynb file in the Explorer → "Open With…" → "Datalayer Notebook Editor", then retry.`,
         );
       }
+      if (!panelStatus.isReady) {
+        throw new Error(
+          `The Datalayer notebook is still loading (webview not ready yet). ` +
+            `Please wait a few seconds for the notebook to fully open, then retry.`,
+        );
+      }
+      const webviewPanel = panelStatus.panel;
 
       const requestId = `${Date.now()}-${Math.random()}`;
 
@@ -543,6 +614,94 @@ function buildOpenDocumentsContext(services: ServiceContainer): string {
 }
 
 /**
+ * Updates the Windsurf global MCP config (`~/.codeium/windsurf/mcp_config.json`)
+ * with the port claimed by this extension instance, then writes a workspace-level
+ * `.windsurf/mcp.json` for transparency/future compatibility.
+ *
+ * **Why global config:** Windsurf only reads `~/.codeium/windsurf/mcp_config.json`
+ * — there is no workspace-level override. Windsurf also hot-reloads that file
+ * when it changes, so no manual refresh is needed after this write.
+ *
+ * **Multi-window behaviour:** each VS Code window claims a different port
+ * (3333-3340). The most-recently-started/reloaded window wins: its port overwrites
+ * the `datalayer` entry in the global config and Windsurf reconnects immediately.
+ * All other entries in `mcp_config.json` are preserved unchanged.
+ *
+ * @param port - The port this MCP server instance is listening on.
+ * @param services - Service container used for logging.
+ */
+async function writeMcpConfig(
+  port: number,
+  services: ServiceContainer,
+): Promise<void> {
+  const os = await import("os");
+  const fs = await import("fs/promises");
+  const path = await import("path");
+
+  const globalConfigPath = path.join(
+    os.homedir(),
+    ".codeium",
+    "windsurf",
+    "mcp_config.json",
+  );
+
+  // ── 1. Update ~/.codeium/windsurf/mcp_config.json ──────────────────────────
+  // Read existing config first so we don't clobber other MCP servers.
+  let existingConfig: { mcpServers?: Record<string, unknown> } = {};
+  try {
+    const raw = await fs.readFile(globalConfigPath, "utf-8");
+    existingConfig = JSON.parse(raw) as typeof existingConfig;
+  } catch {
+    // File doesn't exist yet or is malformed — start with empty object.
+  }
+
+  existingConfig.mcpServers ??= {};
+  existingConfig.mcpServers["datalayer"] = {
+    serverUrl: `http://localhost:${port}/mcp`,
+  };
+
+  try {
+    await fs.writeFile(
+      globalConfigPath,
+      JSON.stringify(existingConfig, null, 2),
+      "utf-8",
+    );
+    services.logger.info(
+      `[MCP] Global Windsurf config updated → ${globalConfigPath} (port ${port})`,
+    );
+  } catch (err) {
+    services.logger.warn(
+      `[MCP] Could not update global Windsurf config: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  // ── 2. Write workspace .windsurf/mcp.json (transparency / future compat) ──
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders?.length) {
+    return;
+  }
+  const windSurfDir = vscode.Uri.joinPath(
+    workspaceFolders[0]!.uri,
+    ".windsurf",
+  );
+  const workspaceConfigPath = vscode.Uri.joinPath(windSurfDir, "mcp.json");
+  const workspaceConfig = {
+    mcpServers: { datalayer: { serverUrl: `http://localhost:${port}/mcp` } },
+  };
+  try {
+    try { await vscode.workspace.fs.createDirectory(windSurfDir); } catch { /**/ }
+    await vscode.workspace.fs.writeFile(
+      workspaceConfigPath,
+      Buffer.from(JSON.stringify(workspaceConfig, null, 2)),
+    );
+  } catch {
+    // Workspace write is best-effort; global config is what matters.
+  }
+}
+
+/**
  * Constructs and returns a configured McpServer with all Datalayer tools registered.
  *
  * A new McpServer instance is created for each HTTP request to ensure stateless
@@ -719,6 +878,11 @@ export async function startMcpServer(
   services.logger.info(
     `Datalayer MCP HTTP server listening on http://127.0.0.1:${port}/mcp (${definitions.length} tools)`,
   );
+
+  // Update ~/.codeium/windsurf/mcp_config.json (and workspace .windsurf/mcp.json)
+  // with this window's port. Windsurf hot-reloads the global config on change,
+  // so no manual refresh is needed after this write.
+  await writeMcpConfig(port, services);
 
   return httpServer;
 }

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -745,6 +745,12 @@ function buildMcpServer(
   const server = new McpServer({ name: "datalayer", version });
 
   for (const definition of definitions) {
+    // datalayer_batch is registered separately below with full closure access
+    // to definitions, operations, and services — skip it in the standard loop.
+    if (definition.name === "datalayer_batch") {
+      continue;
+    }
+
     const operation = operations[definition.operation];
     if (!operation) {
       continue;
@@ -799,6 +805,163 @@ function buildMcpServer(
       },
     );
   }
+
+  // ── Batch tool (Code Mode) ────────────────────────────────────────────────
+  // Registered here rather than through the standard definition→operation loop
+  // so it has closure access to `definitions`, `operations`, and `services`
+  // needed for per-sub-op document resolution via buildMcpExecutionContext.
+  server.registerTool(
+    "datalayer_batch",
+    {
+      title: "Batch Execute Operations",
+      description:
+        "Execute a sequence of Datalayer operations in one call without LLM round-trips between steps. " +
+        "Use this when you have already planned several mechanical steps (e.g. readAllCells → insertCell → runCell → readCell). " +
+        "Each operation runs in order; results are returned as an array. " +
+        "Pass `notebook_uri` or `documentUri` at the top level to target a specific document — these are forwarded to every sub-operation that supports them. " +
+        "Set `stopOnError` to false to continue executing remaining steps after a failure.",
+      inputSchema: {
+        operations: z
+          .array(
+            z.object({
+              tool: z
+                .string()
+                .describe(
+                  "Full tool name, e.g. 'datalayer_insertCell', 'datalayer_runCell'.",
+                ),
+              params: z
+                .record(z.string(), z.unknown())
+                .optional()
+                .describe("Parameters for this tool, identical to calling it directly."),
+            }),
+          )
+          .describe(
+            "Ordered list of operations to execute. Results from earlier steps are not automatically forwarded to later steps — if you need a value (e.g. cell count), retrieve it first with a single tool call, then batch the remaining steps.",
+          ),
+        notebook_uri: z
+          .string()
+          .optional()
+          .describe(
+            "Optional URI of the target notebook. Forwarded to every cell sub-operation. Obtain from datalayer_listOpenDocuments or datalayer_getActiveDocument.",
+          ),
+        documentUri: z
+          .string()
+          .optional()
+          .describe(
+            "Optional URI of the target Lexical document. Forwarded to every block sub-operation. Obtain from datalayer_listOpenDocuments or datalayer_getActiveDocument.",
+          ),
+        stopOnError: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true (default), stop executing remaining steps when one fails. If false, continue and report all errors in results.",
+          ),
+      },
+    },
+    async (args) => {
+      const {
+        operations: subOps,
+        notebook_uri: batchNotebookUri,
+        documentUri: batchDocumentUri,
+        stopOnError = true,
+      } = args as {
+        operations: Array<{ tool: string; params?: Record<string, unknown> }>;
+        notebook_uri?: string;
+        documentUri?: string;
+        stopOnError?: boolean;
+      };
+
+      // Build a name→definition lookup for fast access.
+      const defByName = new Map(definitions.map((d) => [d.name, d]));
+
+      // Validate all tool names upfront — fail fast before executing anything.
+      const unknownTools = subOps
+        .map((op) => op.tool)
+        .filter((name) => !defByName.has(name));
+      if (unknownTools.length > 0) {
+        const validNames = [...defByName.keys()].sort().join(", ");
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Error: Unknown tool(s) in batch: ${unknownTools.join(", ")}.\n` +
+                `Valid tool names: ${validNames}`,
+            },
+          ],
+        };
+      }
+
+      const results: Array<{
+        tool: string;
+        index: number;
+        success: boolean;
+        result?: unknown;
+        error?: string;
+      }> = [];
+
+      for (let i = 0; i < subOps.length; i++) {
+        const subOp = subOps[i]!;
+        const definition = defByName.get(subOp.tool)!;
+        const operation = operations[definition.operation];
+
+        if (!operation) {
+          const errMsg = `No operation registered for tool '${subOp.tool}' (operation: '${definition.operation}')`;
+          results.push({ tool: subOp.tool, index: i, success: false, error: errMsg });
+          if (stopOnError) {
+            break;
+          }
+          continue;
+        }
+
+        // Merge batch-level document URIs into sub-op params.
+        // This enables the fast direct-URI path in resolveNotebookId /
+        // resolveLexicalId (one lookup rather than a full tab/registry scan).
+        const mergedParams: Record<string, unknown> = { ...(subOp.params ?? {}) };
+        if (batchNotebookUri && !mergedParams["notebook_uri"]) {
+          mergedParams["notebook_uri"] = batchNotebookUri;
+        }
+        if (batchDocumentUri && !mergedParams["documentUri"]) {
+          mergedParams["documentUri"] = batchDocumentUri;
+        }
+
+        try {
+          const context = await buildMcpExecutionContext(
+            definition,
+            mergedParams,
+            services,
+          );
+          const result = await operation.execute(mergedParams, context);
+          const formatted = formatResponse(result, context.format ?? "toon");
+          results.push({ tool: subOp.tool, index: i, success: true, result: formatted });
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          results.push({ tool: subOp.tool, index: i, success: false, error: msg });
+          if (stopOnError) {
+            break;
+          }
+        }
+      }
+
+      const succeeded = results.filter((r) => r.success).length;
+      const total = subOps.length;
+      const executed = results.length;
+      const summaryLine =
+        executed < total
+          ? `${succeeded}/${total} succeeded (stopped after step ${executed} due to error)`
+          : `${succeeded}/${total} succeeded`;
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ summary: summaryLine, results }, null, 2),
+          },
+        ],
+      };
+    },
+  );
 
   return server;
 }

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * HTTP MCP server for Windsurf/Cascade integration.
+ *
+ * Exposes all Datalayer tools via the MCP Streamable HTTP transport so that
+ * Cascade can invoke them the same way Copilot does through the VS Code LM API.
+ *
+ * @module mcp/mcpServer
+ */
+
+import type { ToolDefinition, ToolExecutionContext } from "@datalayer/jupyter-react";
+import { formatResponse } from "@datalayer/jupyter-react";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import * as http from "http";
+import * as net from "net";
+import * as vscode from "vscode";
+import { z } from "zod";
+
+import type { Document } from "../models/spaceItem";
+import { getValidatedSettingsGroup } from "../services/config/settingsValidator";
+import type { ServiceContainer } from "../services/core/serviceContainer";
+import type { ExtensionUI } from "../services/ui/uiSetup";
+import {
+  getCombinedOperations,
+} from "../tools/core/registration";
+import { getAllToolDefinitionsAsync } from "../tools/definitions";
+import { analyzeOpenDocuments } from "../utils/documentAnalysis";
+import { getAllOpenedDocuments } from "../utils/getAllOpenedDocuments";
+import {
+  getActiveDatalayerNotebook,
+  validateDatalayerNotebook,
+} from "../utils/notebookValidation";
+
+/** Default MCP HTTP server port. */
+const MCP_DEFAULT_PORT = 3333;
+/** Maximum port to scan before giving up. */
+const MCP_MAX_PORT = 3340;
+
+/**
+ * JSON Schema property descriptor used in tool input schemas.
+ */
+interface JsonSchemaProp {
+  /** JSON Schema type string. */
+  type?: string;
+  /** Human-readable description. */
+  description?: string;
+  /** Nested properties for object types. */
+  properties?: Record<string, JsonSchemaProp>;
+  /** Array item schema. */
+  items?: JsonSchemaProp;
+  /** Enum values. */
+  enum?: unknown[];
+}
+
+/**
+ * JSON Schema object descriptor for a tool's input parameters.
+ */
+interface JsonSchemaObject {
+  /** Must be "object". */
+  type: string;
+  /** Property definitions keyed by parameter name. */
+  properties?: Record<string, JsonSchemaProp>;
+  /** Array of required property names. */
+  required?: string[];
+}
+
+/**
+ * Converts a single JSON Schema property into a Zod schema.
+ * @param prop - JSON Schema property descriptor.
+ *
+ * @returns A Zod schema that validates the property value.
+ */
+function propToZod(prop: JsonSchemaProp): z.ZodTypeAny {
+  if (prop.enum) {
+    const [first, ...rest] = prop.enum as [string, ...string[]];
+    return z.enum([first, ...rest]);
+  }
+  switch (prop.type) {
+    case "string":
+      return z.string();
+    case "number":
+    case "integer":
+      return z.number();
+    case "boolean":
+      return z.boolean();
+    case "array":
+      return z.array(prop.items ? propToZod(prop.items) : z.unknown());
+    case "object": {
+      if (prop.properties) {
+        const shape: Record<string, z.ZodTypeAny> = {};
+        for (const [k, v] of Object.entries(prop.properties)) {
+          shape[k] = propToZod(v);
+        }
+        return z.object(shape).passthrough();
+      }
+      return z.record(z.string(), z.unknown());
+    }
+    default:
+      return z.unknown();
+  }
+}
+
+/**
+ * Converts a JSON Schema object into a Zod raw shape (Record of Zod schemas).
+ * Required fields are kept as-is; optional fields are wrapped in `.optional()`.
+ *
+ * @param schema - JSON Schema object with properties and required array.
+ *
+ * @returns Record mapping parameter names to their Zod schemas.
+ */
+function jsonSchemaToZodShape(
+  schema: JsonSchemaObject,
+): Record<string, z.ZodTypeAny> {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const required = new Set(schema.required ?? []);
+
+  for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+    const base = propToZod(prop);
+    const withDesc = prop.description ? base.describe(prop.description) : base;
+    shape[key] = required.has(key) ? withDesc : withDesc.optional();
+  }
+
+  return shape;
+}
+
+/**
+ * Checks if a TCP port is available by attempting to bind to it briefly.
+ * @param port - The port number to probe.
+ *
+ * @returns Promise resolving to true when the port is free, false otherwise.
+ */
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/**
+ * Scans from `startPort` to `MCP_MAX_PORT` and returns the first free port.
+ * @param startPort - First port to try.
+ *
+ * @returns Promise resolving to the first available port number.
+ *
+ * @throws Error when no port in the range is available.
+ */
+async function findAvailablePort(startPort: number): Promise<number> {
+  for (let port = startPort; port <= MCP_MAX_PORT; port++) {
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  throw new Error(
+    `No available port found in range ${startPort}–${MCP_MAX_PORT}`,
+  );
+}
+
+/**
+ * Reads the full request body from an IncomingMessage stream.
+ * @param req - Node.js incoming HTTP request.
+ *
+ * @returns Promise resolving to the raw body string.
+ */
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Resolves a notebook document ID from tool params or the active Datalayer editor.
+ *
+ * Falls back to the document registry when the active tab is not a Datalayer
+ * notebook (e.g. when VS Code focus is on the Cascade chat panel).
+ *
+ * @param params - Tool input parameters, potentially containing notebook_uri.
+ * @param services - Extension service container for document registry access.
+ *
+ * @returns The resolved document ID or URI string.
+ *
+ * @throws Error when no Datalayer notebook is found.
+ */
+async function resolveNotebookId(
+  params: Record<string, unknown>,
+  services: ServiceContainer,
+): Promise<string> {
+  const uriString = params["notebook_uri"] as string | undefined;
+
+  if (uriString) {
+    const targetUri = vscode.Uri.parse(uriString);
+    validateDatalayerNotebook(targetUri);
+    const uriStr = targetUri.toString();
+    try {
+      return services.documentRegistry.getIdFromUri(uriStr);
+    } catch {
+      return uriStr;
+    }
+  }
+
+  // Try active tab first (works when notebook tab is focused)
+  const activeUri = getActiveDatalayerNotebook();
+  if (activeUri) {
+    const uriStr = activeUri.toString();
+    try {
+      return services.documentRegistry.getIdFromUri(uriStr);
+    } catch {
+      return uriStr;
+    }
+  }
+
+  // Fall back to registry — covers the case where Cascade panel has focus
+  const notebookEntries = services.documentRegistry.getByType("notebook");
+  if (notebookEntries.length > 0) {
+    return notebookEntries[0]!.documentId;
+  }
+
+  throw new Error(
+    "No Datalayer notebook is open. Please open a notebook with the Datalayer editor and try again.",
+  );
+}
+
+/**
+ * Resolves a Lexical document ID from tool params or the active custom editor tab.
+ *
+ * Falls back to the document registry when the active tab is not a Datalayer
+ * lexical document (e.g. when VS Code focus is on the Cascade chat panel).
+ *
+ * @param params - Tool input parameters, potentially containing documentUri.
+ * @param services - Extension service container for document registry access.
+ *
+ * @returns The resolved document ID or URI string.
+ *
+ * @throws Error when no Lexical document is found.
+ */
+async function resolveLexicalId(
+  params: Record<string, unknown>,
+  services: ServiceContainer,
+): Promise<string> {
+  const uriString = params["documentUri"] as string | undefined;
+  let targetUri: vscode.Uri | undefined;
+
+  if (uriString) {
+    targetUri = vscode.Uri.parse(uriString);
+  } else {
+    // Try active tab first
+    const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+    if (activeTab?.input && typeof activeTab.input === "object") {
+      const tabInput = activeTab.input as { uri?: vscode.Uri; viewType?: string };
+      if (tabInput.uri && tabInput.viewType === "datalayer.lexical-editor") {
+        targetUri = tabInput.uri;
+      }
+    }
+  }
+
+  if (!targetUri) {
+    // Fall back to registry — covers the case where Cascade panel has focus
+    const lexicalEntries = services.documentRegistry.getByType("lexical");
+    if (lexicalEntries.length > 0) {
+      return lexicalEntries[0]!.documentId;
+    }
+
+    const activeEditor = vscode.window.activeTextEditor;
+    const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
+    const activeFileName =
+      activeEditor?.document.fileName || activeTab?.label || "nothing";
+    throw new Error(
+      `No Lexical document is open. ` +
+        `Currently active: "${activeFileName}". ` +
+        `Please open a .dlex file and try again.`,
+    );
+  }
+
+  const uriStr = targetUri.toString();
+  try {
+    return services.documentRegistry.getIdFromUri(uriStr);
+  } catch {
+    return uriStr;
+  }
+}
+
+/**
+ * Builds a ToolExecutionContext for use in the MCP handler.
+ *
+ * Mirrors VSCodeToolAdapter.buildExecutionContext but without VS Code Quick Pick
+ * dialogs. The promptForLocation callback defaults to "cloud" when authenticated
+ * and "local" otherwise.
+ *
+ * @param definition - Tool definition including tags and operation name.
+ * @param params - Validated input parameters from the MCP request.
+ * @param services - Extension service container.
+ *
+ * @returns Fully-constructed ToolExecutionContext ready for operation.execute().
+ */
+async function buildMcpExecutionContext(
+  definition: ToolDefinition,
+  params: Record<string, unknown>,
+  services: ServiceContainer,
+): Promise<ToolExecutionContext> {
+  const responseFormat = getValidatedSettingsGroup("tools").responseFormat as
+    | "json"
+    | "toon";
+
+  const documentsContext = getAllOpenedDocuments();
+
+  const needsCellDocument = definition.tags?.includes("cell");
+  const needsBlockDocument = definition.tags?.includes("lexical");
+  const isCreateOperation = definition.tags?.includes("create");
+
+  // Build the webview executor — same postMessage bridge as Copilot path.
+  const executor = {
+    execute: async (operationName: string, args: unknown): Promise<unknown> => {
+      // Use getBestWebviewPanel() rather than getActiveWebviewPanel() so that
+      // operations succeed even when VS Code focus is on the Cascade chat panel
+      // instead of the notebook tab.
+      const webviewPanel = services.documentRegistry.getBestWebviewPanel();
+      if (!webviewPanel) {
+        throw new Error(
+          `No Datalayer notebook or lexical document is open. ` +
+            `Please open a Datalayer notebook or .dlex file, then retry.`,
+        );
+      }
+
+      const requestId = `${Date.now()}-${Math.random()}`;
+
+      return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          listener.dispose();
+          reject(new Error(`Tool execution timeout (30s): ${operationName}`));
+        }, 30000);
+
+        const listener = webviewPanel.webview.onDidReceiveMessage(
+          (message) => {
+            if (
+              message.type === "tool-execution-response" &&
+              message.requestId === requestId
+            ) {
+              clearTimeout(timeoutId);
+              listener.dispose();
+              if (message.error) {
+                reject(new Error(message.error));
+              } else {
+                resolve(message.result);
+              }
+            }
+          },
+        );
+
+        webviewPanel.webview
+          .postMessage({
+            type: "tool-execution",
+            requestId,
+            operationName,
+            args,
+            format: "json",
+          })
+          .then(
+            () => {/* sent */},
+            (err: Error) => {
+              clearTimeout(timeoutId);
+              listener.dispose();
+              reject(new Error(`Failed to send tool-execution message: ${err.message}`));
+            },
+          );
+      });
+    },
+  };
+
+  // Resolve documentId based on tool tags.
+  let documentId: string | undefined;
+  if (!isCreateOperation && needsCellDocument) {
+    documentId = await resolveNotebookId(params, services);
+  } else if (!isCreateOperation && needsBlockDocument) {
+    documentId = await resolveLexicalId(params, services);
+  }
+
+  // Build extras — create operations get a different extras set.
+  let extras: Record<string, unknown>;
+
+  if (isCreateOperation) {
+    const documentAnalysis = analyzeOpenDocuments();
+    extras = {
+      datalayer: services.datalayer,
+      auth: services.authProvider,
+      hasWorkspace: !!vscode.workspace.workspaceFolders,
+      isAuthenticated: services.authProvider.isAuthenticated(),
+      notebookAnalysis: {
+        nativeCount: documentAnalysis.nativeNotebooks.length,
+        localDatalayerCount: documentAnalysis.localDatalayerDocuments.length,
+        cloudDatalayerCount: documentAnalysis.cloudDatalayerDocuments.length,
+        totalCount: documentAnalysis.total,
+        majorityType: documentAnalysis.majorityType,
+      },
+      activeNotebookUri:
+        vscode.window.activeNotebookEditor?.notebook.uri.toString(),
+      openNotebookUris: vscode.workspace.notebookDocuments.map((nb) =>
+        nb.uri.toString(),
+      ),
+      // Non-interactive location selection: prefer cloud when authenticated.
+      promptForLocation: async (
+        _spaceName?: string,
+      ): Promise<"local" | "cloud" | undefined> => {
+        const hasWorkspace = !!vscode.workspace.workspaceFolders;
+        const isAuthenticated = services.authProvider.isAuthenticated();
+        if (isAuthenticated) {
+          return "cloud";
+        }
+        if (hasWorkspace) {
+          return "local";
+        }
+        throw new Error(
+          "Cannot create document: not authenticated to Datalayer and no workspace folder is open.",
+        );
+      },
+      createLocalFile: async (filename: string, content: unknown) => {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+          throw new Error("No workspace folder open");
+        }
+        const uri = vscode.Uri.joinPath(workspaceFolder.uri, filename);
+        await vscode.workspace.fs.writeFile(
+          uri,
+          Buffer.from(JSON.stringify(content, null, 2), "utf-8"),
+        );
+        return uri.toString();
+      },
+      openCloudDocument: async (
+        document: Document,
+        spaceName: string,
+        documentType: "notebook" | "lexical",
+      ) => {
+        const uri = await services.documentBridge.openDocument(
+          document,
+          undefined,
+          spaceName,
+        );
+        const editorId =
+          documentType === "notebook"
+            ? "datalayer.jupyter-notebook"
+            : "datalayer.lexical-editor";
+        await vscode.commands.executeCommand("vscode.openWith", uri, editorId);
+        await vscode.commands.executeCommand("datalayer.refreshSpaces");
+      },
+      documentsContext,
+    };
+  } else {
+    extras = {
+      datalayer: services.datalayer,
+      auth: services.authProvider,
+      kernelBridge: services.kernelBridge,
+      connectRuntimeCallback: async (
+        runtimeName?: string,
+        notebookUri?: string,
+      ) => {
+        await vscode.commands.executeCommand(
+          "datalayer.connectRuntime",
+          runtimeName,
+          notebookUri,
+        );
+        return { podName: runtimeName ?? "default-runtime" };
+      },
+      defaultRuntimeDuration:
+        getValidatedSettingsGroup("runtime").defaultMinutes,
+      defaultRuntimeType: getValidatedSettingsGroup("runtime").defaultType,
+      documentsContext,
+    };
+  }
+
+  return {
+    format: responseFormat,
+    executor,
+    documentId,
+    extras,
+  };
+}
+
+/**
+ * Constructs and returns a configured McpServer with all Datalayer tools registered.
+ *
+ * A new McpServer instance is created for each HTTP request to ensure stateless
+ * operation and avoid transport reuse issues.
+ *
+ * @param definitions - Array of tool definitions providing names, schemas, and tags.
+ * @param operations - Map of operation names to their implementations.
+ * @param services - Extension service container for VS Code API access.
+ * @param version - Extension version string embedded in the server metadata.
+ *
+ * @returns Configured McpServer ready to be connected to a transport.
+ */
+function buildMcpServer(
+  definitions: readonly ToolDefinition[],
+  operations: Record<string, { execute: (params: unknown, ctx: ToolExecutionContext) => Promise<unknown> }>,
+  services: ServiceContainer,
+  version: string,
+): McpServer {
+  const server = new McpServer({ name: "datalayer", version });
+
+  for (const definition of definitions) {
+    const operation = operations[definition.operation];
+    if (!operation) {
+      continue;
+    }
+
+    const jsonSchema = definition.parameters as JsonSchemaObject | undefined;
+    const zodShape = jsonSchema?.properties
+      ? jsonSchemaToZodShape(jsonSchema)
+      : {};
+
+    server.registerTool(
+      definition.name,
+      {
+        title: definition.displayName,
+        description: definition.description,
+        inputSchema: zodShape,
+      },
+      async (args) => {
+        try {
+          const params = args as Record<string, unknown>;
+          const context = await buildMcpExecutionContext(
+            definition,
+            params,
+            services,
+          );
+          const result = await operation.execute(params, context);
+          const formatted = formatResponse(result, context.format ?? "toon");
+          const text =
+            typeof formatted === "string"
+              ? formatted
+              : JSON.stringify(formatted, null, 2);
+          return { content: [{ type: "text" as const, text }] };
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : String(error);
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: `Error: ${msg}` }],
+          };
+        }
+      },
+    );
+  }
+
+  return server;
+}
+
+/**
+ * Starts the Datalayer MCP HTTP server for Windsurf/Cascade.
+ *
+ * Loads the combined tool registry, scans for an available port starting at
+ * MCP_DEFAULT_PORT, and starts a stateless Streamable HTTP MCP server.
+ * Each POST to /mcp spins up a fresh McpServer+transport pair so no session
+ * state leaks between Cascade requests.
+ *
+ * @param _context - VS Code extension context (reserved for future use).
+ * @param services - Initialized service container providing auth and VS Code APIs.
+ * @param _ui - Extension UI components (reserved for future use).
+ *
+ * @returns Promise resolving to the Node.js HTTP server for lifecycle management.
+ *
+ * @throws Error when no port in the default range is available.
+ */
+export async function startMcpServer(
+  _context: import("vscode").ExtensionContext,
+  services: ServiceContainer,
+  _ui: ExtensionUI,
+): Promise<http.Server> {
+  // Load tool registry — lazy to avoid browser-only imports at module load time.
+  const [definitions, operations] = await Promise.all([
+    getAllToolDefinitionsAsync(),
+    getCombinedOperations(),
+  ]);
+
+  const version: string =
+    (vscode.extensions.getExtension("datalayer.datalayer-jupyter-vscode")
+      ?.packageJSON as { version?: string } | undefined)?.version ?? "0.0.0";
+
+  const port = await findAvailablePort(MCP_DEFAULT_PORT);
+
+  const httpServer = http.createServer(async (req, res) => {
+    // Only serve the /mcp endpoint.
+    if (req.url !== "/mcp") {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+
+    // Add CORS headers for local HTTP clients.
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader(
+      "Access-Control-Allow-Methods",
+      "GET, POST, DELETE, OPTIONS",
+    );
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      "Content-Type, MCP-Session-Id",
+    );
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Stateless: new server + transport per request.
+    const mcpServer = buildMcpServer(definitions, operations, services, version);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    res.on("close", () => {
+      transport.close().catch(() => {/* ignore cleanup errors */});
+      mcpServer.close().catch(() => {/* ignore cleanup errors */});
+    });
+
+    try {
+      await mcpServer.connect(transport);
+      const rawBody = await readBody(req);
+      const parsedBody = rawBody ? (JSON.parse(rawBody) as unknown) : undefined;
+      await transport.handleRequest(req, res, parsedBody);
+    } catch (err) {
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: err instanceof Error ? err.message : "Internal error",
+          }),
+        );
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(port, "127.0.0.1", () => {
+      httpServer.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  services.logger.info(
+    `Datalayer MCP HTTP server listening on http://127.0.0.1:${port}/mcp (${definitions.length} tools)`,
+  );
+
+  return httpServer;
+}

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -215,16 +215,21 @@ async function resolveNotebookId(
   if (activeUri) {
     const uriStr = activeUri.toString();
     try {
-      return services.documentRegistry.getIdFromUri(uriStr);
+      const id = services.documentRegistry.getIdFromUri(uriStr);
+      services.documentRegistry.touch(id);
+      return id;
     } catch {
       return uriStr;
     }
   }
 
-  // Fall back to registry — covers the case where Cascade panel has focus
+  // Fall back to registry sorted by most-recently-used — covers the case
+  // where Cascade panel has focus or multiple notebooks are open.
   const notebookEntries = services.documentRegistry.getByType("notebook");
   if (notebookEntries.length > 0) {
-    return notebookEntries[0]!.documentId;
+    const entry = notebookEntries[0]!;
+    services.documentRegistry.touch(entry.documentId);
+    return entry.documentId;
   }
 
   throw new Error(
@@ -378,12 +383,18 @@ async function buildMcpExecutionContext(
     },
   };
 
-  // Resolve documentId based on tool tags.
+  // Resolve documentId based on tool tags, then touch it to update recency.
   let documentId: string | undefined;
   if (!isCreateOperation && needsCellDocument) {
     documentId = await resolveNotebookId(params, services);
+    if (documentId) {
+      services.documentRegistry.touch(documentId);
+    }
   } else if (!isCreateOperation && needsBlockDocument) {
     documentId = await resolveLexicalId(params, services);
+    if (documentId) {
+      services.documentRegistry.touch(documentId);
+    }
   }
 
   // Build extras — create operations get a different extras set.
@@ -487,6 +498,50 @@ async function buildMcpExecutionContext(
 }
 
 /**
+ * Builds a compact open-documents context string appended to every MCP tool
+ * response. This lets the LLM (Cascade) see all registered notebooks and
+ * lexical documents — with their URIs and recency rank — so it can
+ * intelligently select the correct target document based on the user's request
+ * rather than relying solely on extension-side heuristics.
+ *
+ * @param services - Service container providing the document registry.
+ *
+ * @returns A markdown-formatted context block, or an empty string if no
+ *   documents are registered.
+ */
+function buildOpenDocumentsContext(services: ServiceContainer): string {
+  const notebooks = services.documentRegistry.getByType("notebook");
+  const lexicals = services.documentRegistry.getByType("lexical");
+  const allDocs = [...notebooks, ...lexicals];
+
+  if (allDocs.length === 0) {
+    return "";
+  }
+
+  // Sort all docs by lastUsed descending (most recent first).
+  allDocs.sort((a, b) => b.lastUsed - a.lastUsed);
+
+  const lines: string[] = [
+    "",
+    "---",
+    "## Open Datalayer Documents",
+    "Pass `notebook_uri` (for notebooks) or `documentUri` (for lexical docs) from this list to target a specific document.",
+    "",
+  ];
+
+  allDocs.forEach((entry, idx) => {
+    const filename = entry.documentUri.split("/").pop() ?? entry.documentUri;
+    const recency = idx === 0 ? " ← most recent" : "";
+    lines.push(
+      `${idx + 1}. **${filename}** (${entry.type})${recency}`,
+      `   URI: \`${entry.documentUri}\``,
+    );
+  });
+
+  return lines.join("\n");
+}
+
+/**
  * Constructs and returns a configured McpServer with all Datalayer tools registered.
  *
  * A new McpServer instance is created for each HTTP request to ensure stateless
@@ -535,10 +590,21 @@ function buildMcpServer(
           );
           const result = await operation.execute(params, context);
           const formatted = formatResponse(result, context.format ?? "toon");
-          const text =
+          const resultText =
             typeof formatted === "string"
               ? formatted
               : JSON.stringify(formatted, null, 2);
+          // Append the open-documents list only to getActiveDocument responses.
+          // This is the mandatory orientation call, so Cascade gets the full
+          // document context exactly once per session without polluting every
+          // other tool's output.
+          const openDocsContext =
+            definition.name === "datalayer_getActiveDocument"
+              ? buildOpenDocumentsContext(services)
+              : "";
+          const text = openDocsContext
+            ? `${resultText}${openDocsContext}`
+            : resultText;
           return { content: [{ type: "text" as const, text }] };
         } catch (error) {
           const msg =

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -320,8 +320,9 @@ async function buildMcpExecutionContext(
 
   const documentsContext = getAllOpenedDocuments();
 
-  const needsCellDocument = definition.tags?.includes("cell");
-  const needsBlockDocument = definition.tags?.includes("lexical");
+  const isPrerequisiteTool = definition.tags?.includes("prerequisite");
+  const needsCellDocument = !isPrerequisiteTool && definition.tags?.includes("cell");
+  const needsBlockDocument = !isPrerequisiteTool && definition.tags?.includes("lexical");
   const isCreateOperation = definition.tags?.includes("create");
 
   // Build the webview executor — same postMessage bridge as Copilot path.

--- a/src/providers/notebookProvider.ts
+++ b/src/providers/notebookProvider.ts
@@ -420,6 +420,18 @@ export class NotebookProvider extends BaseDocumentProvider<NotebookDocument> {
     };
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
 
+    // Register immediately so MCP tools can find this document even before the
+    // webview sends its "ready" message (which triggers the full handleReadyMessage
+    // registration). Using the URI as the temporary ID is correct for local
+    // notebooks; for cloud notebooks, handleReadyMessage will re-register with
+    // the real documentId once the webview loads.
+    getServiceContainer().documentRegistry.register(
+      document.uri.toString(),
+      document.uri.toString(),
+      "notebook",
+      webviewPanel,
+    );
+
     webviewPanel.webview.onDidReceiveMessage((e) => {
       void this.onMessage(webviewPanel, document, e);
     });
@@ -624,11 +636,19 @@ export class NotebookProvider extends BaseDocumentProvider<NotebookDocument> {
 
     const notebookId = documentId || document.uri.toString();
 
+    // Pass isWebviewReady=true because this call happens after the webview
+    // has sent its "ready" message — the React app is fully loaded.
     getServiceContainer().documentRegistry.register(
       notebookId,
       document.uri.toString(),
       "notebook",
       webviewPanel,
+      true,
+    );
+    // Also mark ready on the early entry (which used uri as ID), in case
+    // both entries exist (e.g. cloud notebook: early uri-keyed + real-id-keyed).
+    getServiceContainer().documentRegistry.markWebviewReady(
+      document.uri.toString(),
     );
 
     this.postMessage(webviewPanel, "init", {

--- a/src/services/documents/documentRegistry.ts
+++ b/src/services/documents/documentRegistry.ts
@@ -113,6 +113,39 @@ class DocumentRegistry {
   }
 
   /**
+   * Get the best available webview panel for tool execution.
+   *
+   * Prefers the currently active Datalayer editor tab (same as
+   * {@link getActiveWebviewPanel}), but when VS Code focus is elsewhere
+   * (e.g. the Cascade/Windsurf MCP chat panel is active), falls back to
+   * the first registered webview panel that is still visible.
+   *
+   * This is required for the MCP path where the user is interacting with
+   * Cascade in a side panel while the notebook tab is open but not focused.
+   *
+   * @returns Best available webview panel, or undefined if none registered.
+   */
+  getBestWebviewPanel(): vscode.WebviewPanel | undefined {
+    // Prefer active tab first (handles the focused-tab case)
+    const active = this.getActiveWebviewPanel();
+    if (active) {
+      return active;
+    }
+
+    // Fall back to any registered panel that is still visible (not disposed).
+    // Prefer notebook panels over lexical ones to match most common MCP use case.
+    for (const type of ["notebook", "lexical"] as const) {
+      for (const entry of this.getByType(type)) {
+        if (entry.webviewPanel) {
+          return entry.webviewPanel;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Unregister a document by its URI (called when webview is closed).
    *
    * @param documentUri - VS Code document URI.

--- a/src/services/documents/documentRegistry.ts
+++ b/src/services/documents/documentRegistry.ts
@@ -38,6 +38,13 @@ export interface DocumentRegistryEntry {
   /** Webview panel for tool execution messaging */
   webviewPanel?: vscode.WebviewPanel;
   /**
+   * Whether the webview has sent its "ready" message, meaning the React app is
+   * fully loaded and the tool-execution message handler is live. Set to false
+   * by the early registration in resolveCustomEditor; set to true by
+   * markWebviewReady() when the "ready" message arrives.
+   */
+  isWebviewReady: boolean;
+  /**
    * Unix timestamp (ms) of the last time this entry was accessed via the MCP
    * executor or explicitly touched. Used to prefer the most-recently-used
    * document when multiple documents of the same type are registered.
@@ -110,12 +117,14 @@ class DocumentRegistry {
     documentUri: string,
     type: DocumentType,
     webviewPanel?: vscode.WebviewPanel,
+    isWebviewReady = false,
   ): void {
     const entry: DocumentRegistryEntry = {
       documentId,
       documentUri,
       type,
       webviewPanel,
+      isWebviewReady,
       lastUsed: Date.now(),
     };
     this.idToEntry.set(documentId, entry);
@@ -150,6 +159,27 @@ class DocumentRegistry {
     const entry = this.idToEntry.get(documentId);
     if (entry) {
       entry.lastUsed = Date.now();
+    }
+  }
+
+  /**
+   * Mark a document's webview as ready to receive tool-execution messages.
+   *
+   * Call this from the provider's handleReadyMessage when the webview React app
+   * has finished loading and sent its "ready" handshake.
+   *
+   * @param documentUri - VS Code document URI string.
+   */
+  markWebviewReady(documentUri: string): void {
+    const documentId = this.uriToId.get(documentUri);
+    if (documentId) {
+      const entry = this.idToEntry.get(documentId);
+      if (entry) {
+        entry.isWebviewReady = true;
+        ServiceLoggers.main.debug(
+          `[DocumentRegistry] Webview ready: ${documentUri.substring(0, 60)}`,
+        );
+      }
     }
   }
 
@@ -190,15 +220,45 @@ class DocumentRegistry {
 
     // Fall back to any registered panel, sorted by most recently used.
     // Prefer notebook panels over lexical ones to match the most common MCP use case.
+    // Within each type, prefer panels where the webview is already ready.
     for (const type of ["notebook", "lexical"] as const) {
       const entries = this.getByType(type);
-      for (const entry of entries) {
-        if (entry.webviewPanel) {
-          return entry.webviewPanel;
-        }
+      const ready = entries.find((e) => e.webviewPanel && e.isWebviewReady);
+      if (ready) {
+        return ready.webviewPanel;
+      }
+      // Fall back to any panel with a webviewPanel, even if not yet ready.
+      const anyPanel = entries.find((e) => e.webviewPanel);
+      if (anyPanel) {
+        return anyPanel.webviewPanel;
       }
     }
 
+    return undefined;
+  }
+
+  /**
+   * Returns the best webview panel AND whether its webview is ready.
+   * Used by the MCP executor to give a precise "still loading" error
+   * instead of a 30-second timeout when the panel exists but the React
+   * app hasn't finished initializing.
+   *
+   * @returns Object with panel and isReady flag, or undefined if no panel found.
+   */
+  getBestWebviewPanelWithStatus():
+    | { panel: vscode.WebviewPanel; isReady: boolean }
+    | undefined {
+    for (const type of ["notebook", "lexical"] as const) {
+      const entries = this.getByType(type);
+      const ready = entries.find((e) => e.webviewPanel && e.isWebviewReady);
+      if (ready) {
+        return { panel: ready.webviewPanel!, isReady: true };
+      }
+      const anyPanel = entries.find((e) => e.webviewPanel);
+      if (anyPanel) {
+        return { panel: anyPanel.webviewPanel!, isReady: false };
+      }
+    }
     return undefined;
   }
 

--- a/src/services/documents/documentRegistry.ts
+++ b/src/services/documents/documentRegistry.ts
@@ -37,6 +37,12 @@ export interface DocumentRegistryEntry {
   type: DocumentType;
   /** Webview panel for tool execution messaging */
   webviewPanel?: vscode.WebviewPanel;
+  /**
+   * Unix timestamp (ms) of the last time this entry was accessed via the MCP
+   * executor or explicitly touched. Used to prefer the most-recently-used
+   * document when multiple documents of the same type are registered.
+   */
+  lastUsed: number;
 }
 
 /**
@@ -58,6 +64,40 @@ class DocumentRegistry {
   private uriToId = new Map<string, string>();
 
   /**
+   * Subscribe to VS Code tab-change events so that manually focusing a
+   * Datalayer custom editor tab also updates `lastUsed`, making it the
+   * preferred target for subsequent MCP tool calls.
+   *
+   * Call once during extension activation and push the returned disposable
+   * onto `context.subscriptions`.
+   *
+   * @returns A VS Code disposable that tears down the listener.
+   */
+  startTabWatcher(): vscode.Disposable {
+    return vscode.window.tabGroups.onDidChangeTabs(() => {
+      const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+      if (!activeTab?.input || typeof activeTab.input !== "object") {
+        return;
+      }
+      const tabInput = activeTab.input as { uri?: vscode.Uri; viewType?: string };
+      if (
+        tabInput.uri &&
+        (tabInput.viewType === "datalayer.jupyter-notebook" ||
+          tabInput.viewType === "datalayer.lexical-editor")
+      ) {
+        const uriStr = tabInput.uri.toString();
+        const documentId = this.uriToId.get(uriStr);
+        if (documentId) {
+          this.touch(documentId);
+          ServiceLoggers.main.debug(
+            `[DocumentRegistry] Tab focus updated lastUsed for: ${uriStr}`,
+          );
+        }
+      }
+    });
+  }
+
+  /**
    * Register a document with its ID, URI, and type.
    *
    * @param documentId - Document identifier (UID for remote, URI for local).
@@ -76,6 +116,7 @@ class DocumentRegistry {
       documentUri,
       type,
       webviewPanel,
+      lastUsed: Date.now(),
     };
     this.idToEntry.set(documentId, entry);
     this.uriToId.set(documentUri, documentId);
@@ -95,6 +136,21 @@ class DocumentRegistry {
     }
     const entry = this.idToEntry.get(documentId);
     return entry?.webviewPanel;
+  }
+
+  /**
+   * Update the last-used timestamp for a document.
+   *
+   * Call this whenever a document is targeted by an MCP tool call so that
+   * recency-based selection prefers the correct document on the next call.
+   *
+   * @param documentId - Document identifier to touch.
+   */
+  touch(documentId: string): void {
+    const entry = this.idToEntry.get(documentId);
+    if (entry) {
+      entry.lastUsed = Date.now();
+    }
   }
 
   /**
@@ -132,10 +188,11 @@ class DocumentRegistry {
       return active;
     }
 
-    // Fall back to any registered panel that is still visible (not disposed).
-    // Prefer notebook panels over lexical ones to match most common MCP use case.
+    // Fall back to any registered panel, sorted by most recently used.
+    // Prefer notebook panels over lexical ones to match the most common MCP use case.
     for (const type of ["notebook", "lexical"] as const) {
-      for (const entry of this.getByType(type)) {
+      const entries = this.getByType(type);
+      for (const entry of entries) {
         if (entry.webviewPanel) {
           return entry.webviewPanel;
         }
@@ -267,9 +324,9 @@ class DocumentRegistry {
    * @returns Array of registry entries.
    */
   getByType(type: DocumentType): DocumentRegistryEntry[] {
-    return Array.from(this.idToEntry.values()).filter(
-      (entry) => entry.type === type,
-    );
+    return Array.from(this.idToEntry.values())
+      .filter((entry) => entry.type === type)
+      .sort((a, b) => b.lastUsed - a.lastUsed);
   }
 
   /**

--- a/src/tools/core/registration.ts
+++ b/src/tools/core/registration.ts
@@ -14,6 +14,7 @@ import type { ToolDefinition, ToolOperation } from "@datalayer/jupyter-react";
 import * as vscode from "vscode";
 
 import { getAllToolDefinitionsAsync } from "../definitions";
+import { batchOperation } from "../operations/batch";
 import { createLexicalOperation } from "../operations/createLexical";
 import { createNotebookOperation } from "../operations/createNotebook";
 import { executeCodeOperation } from "../operations/executeCode";
@@ -43,6 +44,8 @@ export interface CombinedOperations {
   createLexical: ToolOperation<unknown, unknown>;
   /** Executes code in a notebook or runtime. */
   executeCode: ToolOperation<unknown, unknown>;
+  /** Executes a batch of operations in one MCP call (Code Mode). */
+  batch: ToolOperation<unknown, unknown>;
   /** Additional operations from notebook and lexical packages. */
   [key: string]: ToolOperation<unknown, unknown>;
 }
@@ -82,6 +85,9 @@ export async function getCombinedOperations(): Promise<CombinedOperations> {
 
     // Unified code execution (overrides package executeCode operations)
     executeCode: executeCodeOperation,
+
+    // Batch execution (Code Mode — runs multiple ops in one MCP call)
+    batch: batchOperation,
   };
 }
 

--- a/src/tools/core/registration.ts
+++ b/src/tools/core/registration.ts
@@ -19,6 +19,7 @@ import { createNotebookOperation } from "../operations/createNotebook";
 import { executeCodeOperation } from "../operations/executeCode";
 import { getActiveDocumentOperation } from "../operations/getActiveDocument";
 import { listKernelsOperation } from "../operations/listKernels";
+import { listOpenDocumentsOperation } from "../operations/listOpenDocuments";
 import { selectKernelOperation } from "../operations/selectKernel";
 import { VSCodeToolAdapter } from "./toolAdapter";
 
@@ -34,6 +35,8 @@ export interface CombinedOperations {
   selectKernel: ToolOperation<unknown, unknown>;
   /** Gets the currently active document in VS Code. */
   getActiveDocument: ToolOperation<unknown, unknown>;
+  /** Lists all open Datalayer documents sorted by most-recently-used. */
+  listOpenDocuments: ToolOperation<unknown, unknown>;
   /** Creates a new notebook (local or remote). */
   createNotebook: ToolOperation<unknown, unknown>;
   /** Creates a new Lexical document. */
@@ -73,6 +76,7 @@ export async function getCombinedOperations(): Promise<CombinedOperations> {
 
     // VS Code-specific operations (all use standard ToolOperation pattern)
     getActiveDocument: getActiveDocumentOperation,
+    listOpenDocuments: listOpenDocumentsOperation,
     createNotebook: createNotebookOperation,
     createLexical: createLexicalOperation,
 

--- a/src/tools/definitions/batch.ts
+++ b/src/tools/definitions/batch.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * Tool definition: Batch execution of multiple Datalayer operations.
+ *
+ * Implements the Code Mode pattern (inspired by Cloudflare) where the LLM
+ * plans a complete multi-step workflow upfront and sends it in one MCP call,
+ * eliminating LLM round-trips between mechanical steps.
+ */
+
+import type { ToolDefinition } from "@datalayer/jupyter-react";
+
+/** Tool definition for executing a batch of Datalayer operations. */
+export const batchTool: ToolDefinition = {
+  name: "datalayer_batch",
+  displayName: "Batch Execute Operations",
+  toolReferenceName: "batch",
+  description:
+    "Execute a sequence of Datalayer operations in one call without LLM round-trips between steps. Use this when you have already planned several mechanical steps (e.g. readAllCells → insertCell → runCell → readCell). Each operation runs in order; results are returned as an array. Pass `notebook_uri` or `documentUri` at the top level to target a specific document — these are forwarded to every sub-operation that supports them. Set `stopOnError` to false to continue executing remaining steps after a failure.",
+
+  parameters: {
+    type: "object",
+    properties: {
+      operations: {
+        type: "array",
+        description:
+          "Ordered list of operations to execute. Each item specifies the tool name (e.g. 'datalayer_readAllCells') and its params object.",
+        items: {
+          type: "object",
+          properties: {
+            tool: {
+              type: "string",
+              description:
+                "Full tool name, e.g. 'datalayer_insertCell', 'datalayer_runCell', 'datalayer_readAllCells'.",
+            },
+            params: {
+              type: "object",
+              description:
+                "Parameters for this tool, identical to calling it directly. notebook_uri and documentUri are inherited from the top-level batch params unless overridden here.",
+            },
+          },
+          required: ["tool"],
+        },
+      },
+      notebook_uri: {
+        type: "string",
+        description:
+          "Optional URI of the target notebook. Forwarded to every cell sub-operation. Obtain from datalayer_listOpenDocuments or datalayer_getActiveDocument.",
+      },
+      documentUri: {
+        type: "string",
+        description:
+          "Optional URI of the target Lexical document. Forwarded to every block sub-operation. Obtain from datalayer_listOpenDocuments or datalayer_getActiveDocument.",
+      },
+      stopOnError: {
+        type: "boolean",
+        description:
+          "If true (default), stop executing remaining steps when one fails. If false, continue and report all errors in results.",
+      },
+    },
+    required: ["operations"],
+  },
+
+  operation: "batch",
+
+  config: {
+    requiresConfirmation: false,
+    canBeReferencedInPrompt: true,
+    priority: "high",
+  },
+
+  tags: ["batch", "notebook", "lexical"],
+};

--- a/src/tools/definitions/index.ts
+++ b/src/tools/definitions/index.ts
@@ -21,6 +21,7 @@ export * from "./createNotebook";
 
 // Document access tools
 export * from "./getActiveDocument";
+export * from "./listOpenDocuments";
 
 // Kernel management tools
 export * from "./listKernels";
@@ -35,6 +36,7 @@ import { createNotebookTool } from "./createNotebook";
 import { executeCodeTool } from "./executeCode";
 import { getActiveDocumentTool } from "./getActiveDocument";
 import { listKernelsTool } from "./listKernels";
+import { listOpenDocumentsTool } from "./listOpenDocuments";
 import { selectKernelTool } from "./selectKernel";
 
 /**
@@ -58,18 +60,46 @@ async function getAllToolDefinitionsAsync(): Promise<ToolDefinition[]> {
 
   // Filter out executeCode from package tools to avoid duplication
   // Also filter out tools that have missing operations
-  const notebookToolsFiltered = notebookToolDefinitions.filter(
-    (tool: ToolDefinition) =>
-      tool.name !== "datalayer_executeCode" &&
-      tool.name !== "datalayer_insertCells", // Operation doesn't exist
-  );
+  const notebookToolsFiltered = notebookToolDefinitions
+    .filter(
+      (tool: ToolDefinition) =>
+        tool.name !== "datalayer_executeCode" &&
+        tool.name !== "datalayer_insertCells", // Operation doesn't exist
+    )
+    .map((tool: ToolDefinition) => {
+      // Inject notebook_uri into every cell tool's parameter schema.
+      // This optional parameter lets the caller (e.g. Cascade) target a
+      // specific open notebook by URI rather than relying on whichever
+      // notebook happens to be focused in VS Code.
+      // The URI values can be discovered via datalayer_listOpenDocuments.
+      const params = tool.parameters as {
+        type: string;
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      return {
+        ...tool,
+        parameters: {
+          ...params,
+          properties: {
+            notebook_uri: {
+              type: "string",
+              description:
+                "Optional URI of the target notebook. Obtain from datalayer_listOpenDocuments or datalayer_getActiveDocument. Required when multiple notebooks are open and you need to target a specific one.",
+            },
+            ...(params.properties ?? {}),
+          },
+        },
+      };
+    });
   const lexicalToolsFiltered = lexicalToolDefinitions.filter(
     (tool: ToolDefinition) => tool.name !== "datalayer_executeCode_lexical",
   );
 
   return [
-    // Document access (1 tool)
+    // Document access (2 tools)
     getActiveDocumentTool,
+    listOpenDocumentsTool,
 
     // Document creation (2 unified smart tools)
     createNotebookTool,
@@ -112,8 +142,9 @@ async function getAllToolDefinitionsAsync(): Promise<ToolDefinition[]> {
  * Note: insertCells is filtered out because its operation doesn't exist in the package.
  */
 export const allToolDefinitions = [
-  // Document access (1 tool)
+  // Document access (2 tools)
   getActiveDocumentTool,
+  listOpenDocumentsTool,
 
   // Document creation (2 unified smart tools)
   createNotebookTool,

--- a/src/tools/definitions/index.ts
+++ b/src/tools/definitions/index.ts
@@ -30,7 +30,11 @@ export * from "./selectKernel";
 // Code execution tools
 export * from "./executeCode";
 
+// Batch execution tool (Code Mode)
+export * from "./batch";
+
 // Import all definitions for registry
+import { batchTool } from "./batch";
 import { createLexicalTool } from "./createLexical";
 import { createNotebookTool } from "./createNotebook";
 import { executeCodeTool } from "./executeCode";
@@ -112,6 +116,9 @@ async function getAllToolDefinitionsAsync(): Promise<ToolDefinition[]> {
     // Code execution (1 unified tool)
     executeCodeTool,
 
+    // Batch execution (Code Mode — 1 meta-tool)
+    batchTool,
+
     // Notebook tools from package (7 tools, excluding executeCode and insertCells)
     ...notebookToolsFiltered,
 
@@ -126,7 +133,7 @@ async function getAllToolDefinitionsAsync(): Promise<ToolDefinition[]> {
  * DEPRECATED: Use getAllToolDefinitionsAsync() instead to avoid loading React at startup.
  * This export is kept for backwards compatibility but will be removed.
  *
- * This includes 22 tools total (after unifying executeCode and filtering broken tools):
+ * This includes 23 tools total (after unifying executeCode and filtering broken tools):
  * - 6 VS Code-specific tools:
  *   - 2 unified smart document creation tools (createNotebook + createLexical)
  *   - 1 VS Code document access tool (getActiveDocument)

--- a/src/tools/definitions/listOpenDocuments.ts
+++ b/src/tools/definitions/listOpenDocuments.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * Tool definition: List all open Datalayer documents
+ *
+ * Returns every notebook and lexical document currently registered with the
+ * Datalayer editor, sorted by most-recently-used first. Provides the URIs
+ * needed to target a specific document via the `notebook_uri` / `documentUri`
+ * parameter on cell and block tools.
+ */
+
+import type { ToolDefinition } from "@datalayer/jupyter-react";
+
+/** Tool definition for listing all open Datalayer documents. */
+export const listOpenDocumentsTool: ToolDefinition = {
+  name: "datalayer_listOpenDocuments",
+  displayName: "List Open Documents",
+  toolReferenceName: "listOpenDocuments",
+  description:
+    "Returns all Jupyter notebooks and Datalayer lexical documents currently open in the Datalayer editor, sorted by most-recently-used first. " +
+    "Use this to discover available document URIs when multiple notebooks are open. " +
+    "Pass the returned `uri` as `notebook_uri` in notebook cell tools (readAllCells, updateCell, runCell, etc.) " +
+    "or as `documentUri` in lexical block tools to target a specific document directly, " +
+    "without requiring it to be the active VS Code tab.",
+
+  parameters: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+
+  operation: "listOpenDocuments",
+
+  config: {
+    requiresConfirmation: false,
+    canBeReferencedInPrompt: true,
+    priority: "high",
+  },
+
+  tags: ["document", "list", "prerequisite", "notebook", "lexical"],
+};

--- a/src/tools/operations/batch.ts
+++ b/src/tools/operations/batch.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * Batch operation stub for the VS Code / Copilot tool path.
+ *
+ * The full batch execution logic lives in `src/mcp/mcpServer.ts` because it
+ * needs direct access to the combined operations registry, tool definitions,
+ * and `ServiceContainer` (for per-sub-op document resolution via
+ * `buildMcpExecutionContext`). Those are available as closure variables in
+ * `buildMcpServer()` but cannot be threaded cleanly through
+ * `ToolExecutionContext.extras` without coupling every operation to the MCP
+ * layer.
+ *
+ * This stub satisfies the `CombinedOperations` registry and the
+ * `validateToolDefinitions` check so the `datalayer_batch` tool definition
+ * maps to a valid operation name on both the Copilot and MCP paths.
+ *
+ * On the Copilot / VS Code LM API path the stub returns a clear error asking
+ * the caller to use the MCP path instead (Cascade/Windsurf), since batch
+ * execution requires the MCP server's per-request context machinery.
+ */
+
+import type {
+  ToolExecutionContext,
+  ToolOperation,
+} from "@datalayer/jupyter-react";
+
+/** Input type for the batch operation. */
+export interface BatchParams {
+  operations: Array<{ tool: string; params?: Record<string, unknown> }>;
+  notebook_uri?: string;
+  documentUri?: string;
+  stopOnError?: boolean;
+}
+
+/**
+ * Batch operation stub.
+ *
+ * Real execution is handled by the MCP server's `datalayer_batch` handler.
+ * This stub exists so that `validateToolDefinitions` passes and the tool is
+ * visible in the VS Code tool registry.
+ */
+export const batchOperation: ToolOperation<BatchParams, unknown> = {
+  name: "batch",
+
+  async execute(
+    _params: BatchParams,
+    _context: ToolExecutionContext,
+  ): Promise<unknown> {
+    return {
+      error:
+        "datalayer_batch is only available via the Datalayer MCP server (Windsurf/Cascade). " +
+        "Use individual tools (datalayer_readAllCells, datalayer_insertCell, etc.) when calling " +
+        "through the VS Code Copilot tool path.",
+    };
+  },
+};

--- a/src/tools/operations/listOpenDocuments.ts
+++ b/src/tools/operations/listOpenDocuments.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+/**
+ * VS Code-specific tool: List all open Datalayer documents
+ *
+ * Returns every notebook and lexical document currently registered with the
+ * Datalayer editor, sorted by most-recently-used first, so the caller can
+ * pick the correct URI to pass as `notebook_uri` / `documentUri` on
+ * subsequent cell or block tool calls.
+ */
+
+import { getServiceContainer } from "../../extension";
+
+/** A single entry in the open-documents list. */
+export interface OpenDocumentEntry {
+  rank: number;
+  filename: string;
+  uri: string;
+  type: "notebook" | "lexical";
+  mostRecent: boolean;
+}
+
+/** Result returned by the listOpenDocuments operation. */
+export interface ListOpenDocumentsResult {
+  documents: OpenDocumentEntry[];
+  total: number;
+  usage: string;
+}
+
+/**
+ * Lists all Datalayer documents currently open in the editor, sorted by
+ * most-recently-used first.
+ *
+ * @returns List of open documents with URIs and recency rank.
+ */
+export async function listOpenDocuments(): Promise<ListOpenDocumentsResult> {
+  const services = getServiceContainer();
+  const notebooks = services.documentRegistry.getByType("notebook");
+  const lexicals = services.documentRegistry.getByType("lexical");
+
+  const all = [...notebooks, ...lexicals].sort(
+    (a, b) => b.lastUsed - a.lastUsed,
+  );
+
+  const documents: OpenDocumentEntry[] = all.map((entry, idx) => ({
+    rank: idx + 1,
+    filename: entry.documentUri.split("/").pop() ?? entry.documentUri,
+    uri: entry.documentUri,
+    type: entry.type,
+    mostRecent: idx === 0,
+  }));
+
+  return {
+    documents,
+    total: documents.length,
+    usage:
+      "Pass `notebook_uri` (notebook cell tools) or `documentUri` (lexical block tools) from the `uri` field to target a specific document.",
+  };
+}
+
+/**
+ * List Open Documents Operation
+ *
+ * Standard ToolOperation wrapping the listOpenDocuments helper.
+ */
+export const listOpenDocumentsOperation: import("@datalayer/jupyter-react").ToolOperation<
+  Record<string, never>,
+  ListOpenDocumentsResult
+> = {
+  name: "listOpenDocuments",
+
+  async execute(
+    _params: Record<string, never>,
+    _context: import("@datalayer/jupyter-react").ToolExecutionContext,
+  ): Promise<ListOpenDocumentsResult> {
+    return listOpenDocuments();
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ const extensionConfig = {
     "@jupyterlab/completer": "commonjs @jupyterlab/completer",
     "@lexical/react": "commonjs @lexical/react",
     lexical: "commonjs lexical",
+    "@modelcontextprotocol/sdk": "commonjs @modelcontextprotocol/sdk", // MCP SDK uses Node.js built-ins (http, crypto); must not be bundled
     // modules added here also need to be added in the .vscodeignore file
   },
   resolve: {

--- a/webview/global.d.ts
+++ b/webview/global.d.ts
@@ -1,7 +1,0 @@
-/*
- * Copyright (c) 2021-2025 Datalayer, Inc.
- *
- * MIT License
- */
-
-declare module '@jupyterlab/mathjax-extension/style/base.css' {}

--- a/webview/global.d.ts
+++ b/webview/global.d.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021-2025 Datalayer, Inc.
+ *
+ * MIT License
+ */
+
+declare module '@jupyterlab/mathjax-extension/style/base.css' {}

--- a/webview/notebook/main.ts
+++ b/webview/notebook/main.ts
@@ -11,6 +11,7 @@
  */
 
 import "./NotebookEditor";
+import "@jupyterlab/mathjax-extension/style/base.css";
 
 import { setStylesTarget } from "typestyle";
 

--- a/webview/notebook/main.ts
+++ b/webview/notebook/main.ts
@@ -11,7 +11,6 @@
  */
 
 import "./NotebookEditor";
-import "@jupyterlab/mathjax-extension/style/base.css";
 
 import { setStylesTarget } from "typestyle";
 


### PR DESCRIPTION
## Summary

Compatibility for Windsurf's Cascade agent to use Datalayer notebooks similar to Github Copilot.  This had to be done with an MCP server since Windsurf currently doesn't support the same chat API that Copilot uses in VS Code.

## Changes

- Added MCP server exposing the same tools meant to integrate with Windsurf's Cascade agent.  
- Added a 'batch' tool to allow running multiple tools in series (untested / WIP)
- Added functionality for agents to query for any available notebook vs. pulling active notebook (can't work when focus is cascade in the Windsurf IDE)
- Multi-window semi-fix.  Extension starting MCP server only has access to 1 window, MCP server set by most recently opened window.  If an agent asks for a notebook that doesn't exist, added the tooling to check the globalState to see if it's open in a different window - then return a useful message on the issue.

## Checklist

- [ X] `npm run check` passes (format, lint, type-check, README check)
- [ X] `npm run docs` passes with 0 warnings
- [ X] `npm run check:spelling` passes
- [ X] New/modified files have JSDoc on all exports
- [ X] New directories have a `README.md`
- [ X] No `console.log` in production code (use `ServiceLoggers`)
- [ :( ] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)

## Test Plan

<!-- How was this tested? What should reviewers verify? -->

- [ X ] Manual testing in Extension Development Host (F5)
- [ X ] Existing tests pass (`npm test`)
